### PR TITLE
Set domain to wpaccessibility.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Just The Docs is licenced as MIT.
 
 In this initial release the theme is renamed into WP A11y Docs.
 
+The URL for the GitHib pages is wpaccessibility.org.
+
 ### File organisation
 This will be a one design theme only, so all the changes will be done directly in the files itself. This simplifies the code and makes the theme better maintainable. 
 
@@ -25,7 +27,7 @@ For this the following changes were made:
 - Added option for posts and post pagination.
 - Refactored the breadcrumbs for the posts.
 - Removed Just the Docs info pages and create placeholder text to match the actual site structure.
-- Set Ruby to 3.3.6
+- Set Ruby to 3.3.6.
 - Added option to add a canonical URL.
 
 ### SCSS 
@@ -37,23 +39,23 @@ For this the following changes were made:
 - Replaced deprecated global built-in functions by Sass values (sass:map, sass:color, sass:list etc.).
 
 ### CSS color contrast issue
-- placeholder: fixt color contrast and opacity.
+- Placeholder: fixt color contrast and opacity.
 - Fixed color contrast issues for text and non-text meaningful elements.
 
-## Search at the top of the page
+### Search at the top of the page
 - Refactored the HTML of the form to make the HTML valid.
 - Added screen reader feedback to announce number of search results.
 
 ### _config.yml
 
 - Removed Google Analytics Tracking settings.
-- Removed most variable because this is a static site
+- Removed most variable because this is a static site.
 
 ### Accessibility improvements
 
 - Moved the button to expand the submenus to after the submenu link, so the tab order is meaningful.
-- Changed aria-pressed by aria-expanded, see also issue [Change aria-pressed into aria-expanded for buttons connected to expandable content](https://github.com/just-the-docs/just-the-docs/issues/1680)
+- Changed aria-pressed by aria-expanded, see also issue [Change aria-pressed into aria-expanded for buttons connected to expandable content](https://github.com/just-the-docs/just-the-docs/issues/1680).
 - Added `aria-current="page"` to links to the current page.
 - Removed anchor links before headings. The link was inside the heading, resulting in announcing the heading text twice. Maybe we find an accessible way later on.
-- Copy code button is now always visible (not only on hover) and has a larger clickable area. The copy action has now also screenreader feedback
+- Copy code button is now always visible (not only on hover) and has a larger clickable area. The copy action has now also screenreader feedback.
 - The code blocks now have a tabindex="0".

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This site is in development and not ready yet.
 
 The theme is based on the Jekyll theme [Just the docs](https://just-the-docs.github.io/just-the-docs/).
 
-GitHub pages for this repo: [wpaccessibility.github.io/wp-a11y-docs](https://wpaccessibility.github.io/wp-a11y-docs/).
+GitHub pages for this repo: [wpaccessibility.org](https://wpaccessibility.org).
 

--- a/_config.yml
+++ b/_config.yml
@@ -25,8 +25,8 @@ repository: wpaccessibility/wp-a11y-docs # for github-metadata
 
 # prod env
 title: WP Accessibility Knowledge Base
-baseurl: "/wp-a11y-docs" # the sub path of your site, e.g. /blog
-url: "https://wpaccessibility.github.io/" # the base hostname & protocol for your site, e.g. http://example.com
+baseurl: "" # the sub path of your site, e.g. /blog
+url: "https://wpaccessibility.org/" # the base hostname & protocol for your site, e.g. http://example.com
 
 permalink: pretty
 

--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -5,7 +5,7 @@
 
     <p>
       <a href="#top" id="back-to-top" class="back-to-top">
-        <span aria-hidden="true">&#x2191;</span>Back to top
+        <span aria-hidden="true">&#x2191;</span> Back to top
       </a>
     </p>
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "wp-a11y-docs",
-  "version": "0.0.1",
+  "version": "0.1",
   "description": "Jekyll theme for the WP Accessibility Knowledge Base",
   "repository": "wpaccessibility/wp-a11y-docs",
   "license": "MIT",
   "bugs": "https://github.com/wpaccessibility/wp-a11y-docs/issues",
   "devDependencies": {
     "npm-run-all": "^4.1.5",
-    "prettier": "^3.6.0",
-    "stylelint": "^16.21.0",
+    "prettier": "^3.6.2",
+    "stylelint": "^16.22.0",
     "stylelint-config-standard-scss": "^14.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Changes the prod env to https://wpaccessibility.org/

in _config.yml

# prod env
title: WP Accessibility Knowledge Base
baseurl: ""                                     # the sub path of your site, e.g. /blog
url: "https://wpaccessibility.org/" # the base hostname & protocol for your site, e.g. http://example.com
