### PR TITLE
Add "Deploy PR Preview" workflow

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -1,0 +1,54 @@
+name: Deploy PR Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4
+        with:
+          ruby-version: '3.3.6'
+          bundler-cache: true
+          cache-version: 0
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "/pr-preview/pr-${{ github.event.pull_request.number }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./_site
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: deploy
+
+  cleanup-preview:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: remove

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Did we miss a topic? Did you find an error or have a great idea? Create an issue
 
 We would like to [invite you to contribute](/docs/contribute/) to this Knowledge Base.
 
+## Pull Request Previews
+
+When you create a pull request, a preview of your changes will be automatically deployed and a comment will be added to your PR with a link to the preview site. This allows you and reviewers to see how your changes will look before merging.
+
+Preview URLs follow the format: `https://wpaccessibility.org/pr-preview/pr-{number}/`
+
 ## Local install of the website
 
 WPaccessibility.org is written in [Jekyll](https://jekyllrb.com), a static site generator in Ruby using [markdown](https://www.markdownguide.org/) for content.


### PR DESCRIPTION
This pull request introduces automated previews for pull requests, allowing contributors and reviewers to view changes in a live environment before merging. The changes include a new GitHub Actions workflow to build and deploy PR previews, and updates to the documentation to explain the preview feature.

Resolves issue #3 

## PR Preview Automation

* Added `.github/workflows/deploy-pr-preview.yml` workflow to automatically build and deploy a Jekyll site preview for each pull request, and clean up the preview when the PR is closed.

## Documentation Updates

* Updated `README.md` to document the new pull request preview feature, including instructions and preview URL format.

## Demonstration

Before maintainers manually approve the workflow, it cannot be run. So I added a demo to my forked repo: https://github.com/yoren/wp-a11y-docs/pull/2

## Repo Settings Updates

* May consider add: https://docs.github.com/en/actions/how-tos/manage-workflow-runs/approve-runs-from-forks