### PR TITLE
Remove max-height and height, remove padding.

### DIFF
--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -122,11 +122,6 @@
   display: flex;
   min-height: $header-height;
   align-items: center;
-
-  @include mq(md) {
-    height: $header-height;
-    max-height: $header-height;
-  }
 }
 
 .site-title {
@@ -150,8 +145,8 @@
   @include fs-6;
 
   @include mq(md) {
-    padding-top: $sp-2;
-    padding-bottom: $sp-2;
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 


### PR DESCRIPTION
Removing the padding keeps the height aligned with the search assuming no font modifications.

Otherwise, the header is out of alignment by default.

See #44