### PR TITLE
Clarify Documentation Team review process in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,9 @@
 # See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # The Documentation Team own all of the things.
-# They will be asked to review changes to any code in the "main" branch.
-* @wpaccessibility/documentation-team
+# Because this fake-file doesn't exist, the Documentation Team won't be automatically pinged
+# BUT, the members of the Documentation Team are still required to approve a PR for the `main` branch.
+/fake-file.foo @wpaccessibility/documentation-team
 
 # ... except this file; this is kept separate to avoid the above being changed so easily.
 /.github/CODEOWNERS @rianrietveld @GaryJones


### PR DESCRIPTION
Experiment: Update codeowners file so that the Documentation Team aren't automatically requested for a review, but they are still required for PR approval.