### PR TITLE
Adds starter content menu Start with accessibility

### DIFF
--- a/docs/start/at/index.md
+++ b/docs/start/at/index.md
@@ -1,0 +1,17 @@
+---
+title: Assistive technology
+layout: default
+parent: Start with accessibility
+nav_order: 5
+---
+
+# Assistive technology
+
+**TODO:** Add (links to) content, demos and to how to test about the different ways people use the web
+- keyboard only
+- screen reader
+- braille line
+- voice recognition software
+- zoom
+- [ ... ]
+

--- a/docs/start/business/index.md
+++ b/docs/start/business/index.md
@@ -1,0 +1,22 @@
+---
+title: Accessibility for your business
+layout: default
+parent: Start with accessibility
+nav_order: 4
+---
+
+# Accessibility for your business
+
+**TODO**: Add information about the European Accessibility Act (EAA).
+
+An inclusive website enhances your business. It will:
+
+- **Increase Traffic**. More people can complete orders in your web shop.
+- **Comply with the Law**. Your website is better prepared to adhere to your nation’s accessibility regulations and government contract requirements.
+- **Improve SEO**. Google, the largest user of the internet, is blind and deaf.
+
+The website you build is not for you, or even your client. It’s for the users. Increasing accessibility instantly gains you a larger potential user-base.
+
+Entire countries are among this increased user-base: Israel, Norway and Australia require all company websites to be accessible. Many other nations have laws regarding website accessibility. The WAI provides an overview on [Web Accessibility Laws & Policies](https://www.w3.org/WAI/policies/).
+
+Another vital group of users with neither sight nor hearing are search engines. Improving accessibility improves your site’s Google visibility, thus improving your search engine optimization.

--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -6,5 +6,38 @@ nav_order: 2
 
 # Start with accessibility
 
+## What is web accessibility?
 
-Content follows.
+<blockquote>
+    <p>Web accessibility refers to the inclusive practice of removing barriers that prevent access to websites by people with disabilities.</p>
+    <cite> — <a href="http://en.wikipedia.org/wiki/Web_accessibility">Wikipedia</a></cite>
+</blockquote>
+
+The Web is for everyone, not just those who see, hear and move well. Building your website for inclusion, rather than exclusion, increases access for people of all abilities; as well as for all types of browsers and search engines.
+
+## What does a11y mean?
+
+Accessibility is often abbreviated as a11y; “a” is the first character of the word, and “y” the last , with 11 characters in between. (similar to i18n for “internationalization”). So when you tweet about accessibility, use the hashtags #a11y or #wpa11y.
+
+## Include everyone
+
+By adopting the accessibility best practices you can ensure your website can be used by a large group of different people. Don't create for perfect people only. More about this in [They're not my visitors](/docs/start/myths/personas/).
+
+## Consider your business
+
+The website you build is not for you, or even your client. It’s for the users. Increasing accessibility instantly gains you a larger potential user-base. Read about the business case in [Accessibility for your business](/docs/start/business/).
+
+## Consider your development process
+
+For developers web accessibility means a way of thinking often called progressive enhancement:
+
+- Let the HTML tell the content.
+- Let the CSS present the content.
+- Let the JavaScript interact with the content.
+
+This division helps you create websites that are easier to maintain and update, and is considered to be a (c)lean approach to web development.
+[Standards and best practice](/docs/topics/) explains how to code with sematics and accessibility in mind.
+
+## In Summary
+
+A11y includes everyone when building websites. Think of it as your ally in optimizing your website’s user-experience, for as many people as possible, while furthering your business or organizational goals.

--- a/docs/start/myths/index.md
+++ b/docs/start/myths/index.md
@@ -1,0 +1,10 @@
+---
+title: Debunking myths
+layout: default
+parent: Start with accessibility
+nav_order: 6
+---
+
+# Debunking accessibility myths
+
+**TODO**: add into text.

--- a/docs/start/myths/overlays.md
+++ b/docs/start/myths/overlays.md
@@ -1,0 +1,16 @@
+---
+title: Overlays
+layout: default
+parent: Debunking myths
+nav_order: 3
+---
+
+# Overlays
+
+**TODO**: Add content:
+- what is an overlay
+- to consider: WP plugins for overlays and their claim (maybe not) 
+- the difference between an overlay and a toolbar
+- link to [overlayfactsheet.com](https://overlayfactsheet.com/en/)
+- include video [Overlays Underwhelm](https://www.youtube.com/live/RDkqJaBwgKU?si=4K5oAYp0ttz7jmNj).
+- add more resources from within the WP community

--- a/docs/start/myths/personas.md
+++ b/docs/start/myths/personas.md
@@ -1,0 +1,33 @@
+---
+title: They're not my visitors
+layout: default
+parent: Debunking myths
+nav_order: 2
+---
+
+# They're not my visitors
+
+We often design and build for a perfect user in a perfect setting: someone who’s young, healthy, full of energy, tech-savvy, well-rested, sitting in a quiet room, free from distractions, not hungover, sipping coffee, and with all the time in the world.
+
+But is that your visitor, is that even you? 
+
+For example: did you ever watch a video in a full, noisy train, and you forgot your headset? Wouldn't it be nice to have captioning of the spoken text of the video.
+
+## Consider these people
+
+- Cheyenne has arthritis and cannot use a mouse, She uses a keyboard but cannot activate a hamburger menu.
+- Carel has Parkinson’s disease. His hands are not steady enough to mouse-click on a link with tiny text.
+- Louis uses a screen reader. He struggles to understand a page’s content because its markup has no logical heading structure.
+- Kaia is blind. Links that are an image or an icon font, with no link text, are effectively invisible to her.
+- Carlos is color blind. He can’t distinguish the red links from the black text.
+- Ray is in his 60s. His eyesight has degraded. He can no longer read small grey text on top a darker grey background.
+- Braiden has ADD (Attention Deficit Disorder). A distracting animation in the sidebar, with no user-control for stopping, prevents her from focusing on the page content.
+- Alyssa is deaf. A video without subtitles is unusable to her.
+- Yurem has Down syndrome. He can’t comprehend the content of a webpage because the writing is unnecessarily complicated.
+- Jabari lives in Western Africa. He has a slow Internet connection. Sites bloated with heavy scripts and images keep him from browsing a substantial portion of the Web.
+
+These people, and many more like them, already face lots of life challenges. By adopting the a11y best practices you can ensure your website does not add their challenges.
+
+## Resources
+
+- [Blind people don’t visit my website](https://www.a11y-collective.com/blog/blind-people-dont-visit-my-website/) by The A11Y Collective.

--- a/docs/start/quick-wins/index.md
+++ b/docs/start/quick-wins/index.md
@@ -1,0 +1,32 @@
+---
+title: Quick wins
+layout: default
+parent: Start with accessibility
+nav_order: 1
+---
+
+# Quick wins
+
+**TODO**: Add links when there is content to link to in [Standards and Practice](/docs/topics/).
+
+What to do first? Start with the low-hanging fruit. Color contrast of text ia an easy fix. Alternative text with images probably too.
+
+The most made errors reported in the yearly report [WebAIM Million](https://webaim.org/projects/million/) are:
+
+- Low color contrast for texttext
+- Missing Alternative Text on images
+- Missing labels in forms
+- Empty links
+- Empty buttons
+- Missing language in the `<html>` element
+
+96% of all errors detected fall into these six categories. 
+
+So: if these errors are all sorted, you are already better than 96% of the web.
+
+**TODO**: Add content about what you can do when you can't change your WordPress theme yourself.
+
+
+
+
+

--- a/docs/start/training/index.md
+++ b/docs/start/training/index.md
@@ -1,0 +1,15 @@
+---
+title: Training
+layout: default
+parent: Start with accessibility
+nav_order: 3
+---
+
+# Training, learn web accessibility
+
+**TODO**: Add more resources.
+
+## Online Courses
+
+Mike Gifford maintains a large list of courses, webinars, educational videos and more, offered in web accessibility: [a11y-courses](https://github.com/mgifford/a11y-courses).
+

--- a/docs/start/wcag-intro/index.md
+++ b/docs/start/wcag-intro/index.md
@@ -1,0 +1,85 @@
+---
+title: Introduction to WCAG
+layout: default
+parent: Start with accessibility
+nav_order: 2
+---
+
+# Introduction to WCAG
+
+The primary guidance for web accessibility on a global basis are the Web Content Accessibility Guidelines, commonly referred to as WCAG. WordPress requires that all content meet WCAG guidelines, but also pushes to provide accessibility beyond that minimum whenever possible. 
+
+These guidelines are created and updated by the Web Accessibility Initiative (WAI), a part of the international World Wide Web Consortium (W3C).
+
+WordPress Accessibility Coding Standard:
+<blockquote>
+    <p>All new or updated code released in WordPress must conform with the WCAG 2.2 guidelines at level AA.</p>
+    <cite><a href="https://make.wordpress.org/core/handbook/best-practices/coding-standards/accessibility-coding-standards/">WordPress Accessibility Coding Standard</a></cite>
+</blockquote>
+
+## WCAG explained
+
+When building a new website, theme, or plugin, ask yourself these four questions:
+
+- Is all content available to everyone? (Perceivable)
+- Can visitors use all functionality? (Operable)
+- Can visitors comprehend all content? (Understandable)
+- Can visitors use any device? (Robust)
+
+These are the four principles of Web Content Accessibility Guidelines (WCAG) of what a website should be: perceivable, operable, understandable and robust.
+
+### Perceivable
+
+Is all content available to everyone?
+
+- Provide text alternatives for non-text content (e.g., images).
+- Provide captions and other alternatives for multimedia.
+- Create content that can be presented in different ways without losing meaning.
+- Make it easy for users to see and hear content (e.g., by using color well, offering multimedia controls, and allowing text resizing).
+
+### Operable
+
+Can visitors use all functionality?
+
+- Make all essential functionality available from a keyboard.
+- Give users enough time to read and use content.
+- Do not use content that causes seizures.
+- Help users navigate and find content.
+
+### Understandable
+
+Can visitors comprehend all content?
+
+- Make text readable and understandable.
+- Use easy-to-comprehend text — avoid complex wording.
+- Make content appear and operate in predictable ways.
+- Guide users to avoid and correct mistakes.
+
+### Robust
+
+Can visitors use any device?
+
+- Content must be able to be interpreted reliably by a wide variety of user agents, including assistive technologies.
+- All user interface components should have programmatically determinable names and roles.
+
+## Levels of Accessibility
+
+There are 3 levels of accessibility:
+
+- A (basic)
+- AA (the global accessibility standard)
+- AAA (for dedicated software)
+
+TODO: add content about version
+
+TODO: add info about different principle/ guideline/succes criteria/technique.
+
+Most European Union and many other countries use the accessibility standard WCAG 2.1 AA or equivalent for their government websites. Some countries require compliance with these guidelines for commercial websites, so the accessibility team uses these guidelines to improve WordPress core. [Overview of government accessibility laws and policies](Web Accessibility Laws & Policies) from the Web Accessibility Initiative.
+
+The [WCAG Quick Reference](https://www.w3.org/WAI/WCAG22/quickref/) is a good starting to read the guidelines. Use common sense when following WCAG techniques. Pick the one(s) that work well with your theme or plugin.
+
+Decide which browser and versions your theme or plugin will support. Some WCAG techniques apply only to older browsers, e.g, Internet Explorer 7 and below. WordPress no longer supports Internet Explorer as of version 5.8.
+
+TODO: what is the WP baseline now? A link may be better.
+
+TODO: Link to Standards and best practice/ WCAG (to be written) for more in dept info


### PR DESCRIPTION
Related issue #58

To set up the structure of the site and to be able to cross link in the documentation, this PR adds pages, some with todos about the content that needs to e added, some with content taken from the [current Handbook](https://make.wordpress.org/accessibility/handbook/).

From the TODOs new issues will be written after the PR has been merged.

