### PR TITLE
Fix the focused nav item has their right or left outline cut off

### DIFF
--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -102,6 +102,14 @@
   }
 }
 
+.site-header,
+.site-nav {
+  a:focus,
+  a:focus-visible {
+    outline-offset: -1px;
+  }
+}
+
 .site-nav {
   display: none;
 

--- a/_sass/layout/_layout.scss
+++ b/_sass/layout/_layout.scss
@@ -106,7 +106,7 @@
 .site-nav {
   a:focus,
   a:focus-visible {
-    outline-offset: -1px;
+    outline-offset: -2px;
   }
 }
 


### PR DESCRIPTION
This PR fixes #45 

When testing in Chrome, I noticed that it's not only the navigation items, but also the header title and sub nav items also get their right focused outline cut off.

Consider the cut-off is basically due to the border is rendered outside of the box, offsetting for 1px is seeming the easiest way to resolve it.