### PR TITLE
66 Add content about training

### DIFF
--- a/docs/start/training/index.md
+++ b/docs/start/training/index.md
@@ -7,9 +7,23 @@ nav_order: 3
 
 # Training, learn web accessibility
 
-**TODO**: Add more resources.
 
-## Online Courses
+## WP Accessibility Day
 
-Mike Gifford maintains a large list of courses, webinars, educational videos and more, offered in web accessibility: [a11y-courses](https://github.com/mgifford/a11y-courses).
+[WP Accessibility Day](https://wpaccessibility.day/) is an online event with a 24-hour single track of presentations. Attendees can register for free and watch live streams of talks held via Zoom with live captions and American Sign Language (ASL) Interpretation. After the conference ends, presentations are edited, transcribed, captioned, and made freely available on the web.
+
+## WordPress Accessibility Meetup
+
+The [WordPress Accessibility Meetup](https://www.meetup.com/wordpress-accessibility-meetup-group/) is a global group of WordPress developers, designers, and users interested in building more accessible websites. Join us twice per month for meetups on a variety of topics related to making WordPress websites that can be used by people of all abilities.
+
+## Online training
+There are many places around the internet where you can learn more about Accessibility either within the WordPress ecosystem or as a general technical concept. Here are a few suggestions:
+
+- [WordPress Accessibility at LinkedIn Learning](https://www.linkedin.com/learning/wordpress-accessibility-22376834). Learn about accessibility within WordPress from Joe Dolson, a WordPress core committer and contributor to the accessibility team.
+- [The A11y Collective](https://www.a11y-collective.com/). A wide variety of online courses about accessibility on the web.
+- [Deque University](https://dequeuniversity.com/) – Training and on-demand reference materials covering a wide variety of accessibility topics.
+- [Course path on Website Accessibility at PluralSight](https://www.pluralsight.com/paths/developing-websites-for-accessibility). A series of courses on many aspects of website accessibility.
+- [Lesson Plan on Theme Accessibility](https://learn.wordpress.org/lesson-plan/theme-accessibility/). Advice from [Learn WordPress ](https://learn.wordpress.org/) about making a theme accessible. 
+- Mike Gifford maintains a large list of courses, webinars, educational videos and more, offered in web accessibility: [a11y-courses](https://github.com/mgifford/a11y-courses).
+
 


### PR DESCRIPTION
Adds the content of [Education Opportunities](https://make.wordpress.org/accessibility/handbook/which-tools-can-i-use/education-opportunities/) from the handbook to the page Start with accessibility > [Training](https://wpaccessibility.org/docs/start/training/).