### PR TITLE
Improve accessibility of the search option by adding results page

### DIFF
--- a/_includes/components/search_header.html
+++ b/_includes/components/search_header.html
@@ -1,11 +1,24 @@
-
 <div class="search">
-  <form class="search-input-wrap" role="search">
-    <input type="text" id="search-input" name="q" class="search-input" placeholder="Search {{site.title}}" autocomplete="off">
+  <form class="search-input-wrap" role="search" action="/search/" method="get">
     <label for="search-input" class="search-label">
-      <span class="screen-reader-text">Search {{site.title}}</span>
-      <svg viewBox="0 0 24 24" class="search-icon" aria-hidden="true"><use xlink:href="#svg-search"></use></svg>
+      <span class="screen-reader-text">Search {{ site.title }}</span>
+      <svg viewBox="0 0 24 24" class="search-icon" aria-hidden="true">
+        <use xlink:href="#svg-search"></use>
+      </svg>
     </label>
+
+    <input 
+      type="search" 
+      id="search-input" 
+      name="q" 
+      class="search-input" 
+      placeholder="Search {{ site.title }}" 
+      aria-label="Search {{ site.title }}" 
+      autocomplete="off"
+    >
+
+    <button type="submit" class="search-submit">Search</button>
   </form>
+
   <div id="search-results" class="search-results"></div>
 </div>

--- a/assets/js/wp-a11y-docs.js
+++ b/assets/js/wp-a11y-docs.js
@@ -88,6 +88,9 @@ function initSearch() {
       });
 
       searchLoaded(index, docs);
+      window.jtdSearchIndex = index;
+      window.jtdSearchDocs = docs;
+
     } else {
       console.log('Error loading ajax request. Request status:' + request.status);
     }
@@ -429,11 +432,12 @@ function searchLoaded(index, docs) {
         var active = document.querySelector('.search-result.active');
         if (active) {
           active.click();
-        } else {
-          var first = document.querySelector('.search-result');
-          if (first) {
-            first.click();
-          }
+        } 
+        else {
+            var inputValue = searchInput.value.trim();
+            if (inputValue.length > 0) {
+              window.location.href = '/search/?q=' + encodeURIComponent(inputValue);
+            }
         }
         return;
     }
@@ -560,3 +564,43 @@ jtd.onReady(function(){
 });
 
 })(window.jtd = window.jtd || {});
+
+// ---------------------------
+// Full Search Results Page
+// ---------------------------
+document.addEventListener("DOMContentLoaded", function () {
+  const urlParams = new URLSearchParams(window.location.search);
+  const query = urlParams.get("q");
+
+  if (query) {
+    const resultsContainer = document.getElementById("search-results-page");
+    if (resultsContainer) {
+      // Ensure index and docs exist
+      if (window.jtdSearchIndex && window.jtdSearchDocs) {
+        const index = window.jtdSearchIndex;
+        const docs = window.jtdSearchDocs;
+
+        let results = index.search(query);
+
+        if (results.length > 0) {
+          resultsContainer.innerHTML = `
+            <p>${results.length} results found for "<strong>${query}</strong>"</p>
+            <ul>
+              ${results.map(r => {
+                const doc = docs[r.ref];
+                return `
+                  <li>
+                    <a href="${doc.url}">${doc.title}</a><br>
+                    <small>${doc.relUrl}</small>
+                  </li>`;
+              }).join("")}
+            </ul>
+          `;
+        } else {
+          resultsContainer.innerHTML = `<p>No results found for "<strong>${query}</strong>".</p>`;
+        }
+      }
+    }
+  }
+});
+

--- a/search.html
+++ b/search.html
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Search Results
+---
+<h1>Search Results</h1>
+<div id="search-results-page" role="region" aria-live="polite">
+  <p>Loading search results…</p>
+</div>


### PR DESCRIPTION
This PR improves the accessibility of the search functionality by:

Adding a dedicated search.html page to display search results with proper headings and regions.

Updating the search form to include a submit action (action="/search/") so users can navigate to a full search results page.

Ensuring screen reader feedback is available for both the dropdown and the results page (aria-live="polite").

Why
Previously, search only displayed a dropdown with results and provided limited screen reader feedback. With these changes, users (especially screen reader users) can now:

Submit a search query and access results on a separate page.

Navigate results more easily with semantic HTML and ARIA support.