### PR TITLE
Update GitHub Actions workflows to replace pr-preview-action

### DIFF
--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -59,10 +59,25 @@ jobs:
         run: find ./site -maxdepth 4 -type f | head -100
 
       - name: Deploy PR Preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          source-dir: ./site
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          pages-base-url: wpaccessibility.org
-          action: deploy
+          branch: gh-pages
+          folder: ./site
+          target-folder: pr-preview/pr-${{ steps.pr.outputs.pr_number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get timestamp (UTC)
+        id: ts
+        run: echo "utc=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+
+      - name: Post preview link as sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ steps.pr.outputs.pr_number }}
+          header: pr-preview
+          message: |
+            [PR Preview](https://wpaccessibility.org/pr-preview/pr-${{ steps.pr.outputs.pr_number }}/)
+            :---:
+            Preview deployed for PR #${{ steps.pr.outputs.pr_number }}.
+            ${{ steps.ts.outputs.utc }}
+            <!-- Sticky Pull Request Commentpr-preview -->

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: pr-cleanup-${{ github.event.pull_request.number }}
@@ -18,9 +19,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Cleanup PR Preview for PR #${{ github.event.pull_request.number }}
-        uses: rossjrw/pr-preview-action@v1
+      - name: Create empty deploy folder
+        run: mkdir -p empty
+
+      - name: Remove PR Preview folder using GitHub Pages Deploy Action
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          preview-branch: gh-pages
-          umbrella-dir: pr-preview
-          action: remove
+          branch: gh-pages
+          folder: ./empty
+          target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          clean: true
+
+      - name: Get timestamp (UTC)
+        id: ts
+        run: echo "utc=$(date -u '+%Y-%m-%d %H:%M UTC')" >> "$GITHUB_OUTPUT"
+
+      - name: Post removal sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          number: ${{ github.event.pull_request.number }}
+          header: pr-preview
+          message: |
+            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) v1
+            :---:
+            Preview removed because the pull request was closed.
+            ${{ steps.ts.outputs.utc }}
+            <!-- Sticky Pull Request Commentpr-preview -->


### PR DESCRIPTION
We had to replace the `pr-preview-action` with another action that supporting our use case. The author doesn't support forked PRs for security reasons: https://github.com/rossjrw/pr-preview-action/pull/6 So we shall also keep in mind with that.

This pull request updates the PR preview deployment and cleanup workflows to use the more robust `github-pages-deploy-action` instead of the previous `pr-preview-action`. It also improves visibility for contributors by posting sticky comments with preview links and timestamps on pull requests.

**Deployment workflow improvements:**

* Switched from `rossjrw/pr-preview-action` to `JamesIves/github-pages-deploy-action@v4` for deploying PR previews, allowing more flexible folder targeting and improved reliability. (`.github/workflows/pr-deploy-preview.yml`)
* Added a step to post a sticky comment on the PR with the preview link and UTC timestamp, improving contributor awareness and traceability. (`.github/workflows/pr-deploy-preview.yml`)

**Cleanup workflow improvements:**

* Updated permissions to allow writing pull request comments, enabling sticky comment functionality. (`.github/workflows/pr-preview-cleanup.yml`)
* Replaced preview removal logic with `github-pages-deploy-action@v4`, deploying an empty folder to effectively remove the preview, and added a sticky comment to notify contributors of the removal with a timestamp. (`.github/workflows/pr-preview-cleanup.yml`)