### PR TITLE
Fix the clean up workflow failure

### DIFF
--- a/.github/workflows/pr-deploy-preview.yml
+++ b/.github/workflows/pr-deploy-preview.yml
@@ -76,8 +76,8 @@ jobs:
           number: ${{ steps.pr.outputs.pr_number }}
           header: pr-preview
           message: |
-            [PR Preview](https://wpaccessibility.org/pr-preview/pr-${{ steps.pr.outputs.pr_number }}/)
+            **PR Preview**
             :---:
-            Preview deployed for PR #${{ steps.pr.outputs.pr_number }}.
+            :rocket: View PR Preview at https://wpaccessibility.org/pr-preview/pr-${{ steps.pr.outputs.pr_number }}.
+            If you see a 404 error, please wait a few minutes and refresh the page.
             ${{ steps.ts.outputs.utc }}
-            <!-- Sticky Pull Request Commentpr-preview -->

--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -19,14 +19,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create empty deploy folder
-        run: mkdir -p empty
-
       - name: Remove PR Preview folder using GitHub Pages Deploy Action
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: ./empty
+          folder: ./site
           target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: true
@@ -41,8 +38,7 @@ jobs:
           number: ${{ github.event.pull_request.number }}
           header: pr-preview
           message: |
-            [PR Preview Action](https://github.com/rossjrw/pr-preview-action) v1
+            **PR Preview**
             :---:
             Preview removed because the pull request was closed.
             ${{ steps.ts.outputs.utc }}
-            <!-- Sticky Pull Request Commentpr-preview -->


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows responsible for deploying and cleaning up PR preview environments. The main improvements are in the formatting and clarity of PR preview messages, and a fix to the cleanup workflow to ensure the correct folder is removed.

**PR Preview Message Improvements:**

* Updated the PR preview deployment message to use a clearer format with bold headers and a direct link, including instructions for handling 404 errors. (`.github/workflows/pr-deploy-preview.yml`)
* Updated the PR preview cleanup message to use a consistent bold header, improving readability. (`.github/workflows/pr-preview-cleanup.yml`)

**Cleanup Workflow Fix:**

* Fixed the cleanup workflow to remove the correct PR preview folder by specifying `./site` instead of an empty folder, ensuring proper cleanup of preview deployments. (`.github/workflows/pr-preview-cleanup.yml`)