### PR TITLE
Fix the cleanup step settings and permissions

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -1,7 +1,7 @@
 name: Remove PR Preview
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
 
 permissions:
@@ -19,11 +19,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Create empty deploy folder
+        run: mkdir -p empty
+
       - name: Remove PR Preview folder using GitHub Pages Deploy Action
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
-          folder: ./site
+          folder: ./empty
           target-folder: pr-preview/pr-${{ github.event.pull_request.number }}
           token: ${{ secrets.GITHUB_TOKEN }}
           clean: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow responsible for cleaning up PR preview deployments. The main change is to ensure the PR preview folder is properly removed when a pull request is closed by deploying an empty folder instead of the previous site folder.

Workflow trigger update:

* Changed the workflow trigger from `pull_request` to `pull_request_target` to ensure the workflow runs with the correct permissions when a PR is closed.

PR preview cleanup improvements:

* Added a step to create an empty deployment folder (`empty`) and configured the deploy action to use this folder, ensuring that the PR preview is fully removed from GitHub Pages when the PR is closed.