### PR TITLE
Fix spelling error in accessibility guide reference

### DIFF
--- a/docs/testing/checklists/index.md
+++ b/docs/testing/checklists/index.md
@@ -12,7 +12,7 @@ This content needs to be reviewed and expanded.
 Related issue on [GitHub #170 Checklists for accessibility testing overall](https://github.com/wpaccessibility/wp-a11y-docs/issues/170).    
 If you want to work on this, please let us know before you start.
 
-[Accessibility testing guide](https://github.com/alphagov/wcag-primer/wiki) by the Britisch Government Digital Service. For testing websites and applications against the Web Content Accessibility Guidelines (WCAG) 2.2 AA Level. A detailed checklist per WCAG Success criterion.
+[Accessibility testing guide](https://github.com/alphagov/wcag-primer/wiki) by the British Government Digital Service. For testing websites and applications against the Web Content Accessibility Guidelines (WCAG) 2.2 AA Level. A detailed checklist per WCAG Success criterion.
 
 [Check your WCAG compliance](https://www.a11yproject.com/checklist/) by the A11y Project. The checks are ordered by topic.
 


### PR DESCRIPTION
Corrected the spelling of 'British' in the accessibility testing guide reference.