### PR TITLE
Use flex for menu items layout

### DIFF
--- a/_sass/layout/_navigation.scss
+++ b/_sass/layout/_navigation.scss
@@ -19,6 +19,9 @@
   .nav-list-item {
     position: relative;
     margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 
     @include fs-4;
 
@@ -33,6 +36,8 @@
       padding-top: $sp-1;
       padding-bottom: $sp-1;
       line-height: #{$nav-list-item-height-sm - 2 * $sp-1};
+      flex: 1;
+
       @if $nav-list-expander-right {
         padding-right: $nav-list-item-height-sm;
         padding-left: $gutter-spacing-sm;
@@ -71,15 +76,12 @@
     }
 
     .nav-list-expander {
-      position: absolute;
-      @if $nav-list-expander-right {
-        right: 5px;
-      }
-
       width: $nav-list-item-height-sm;
       height: $nav-list-item-height-sm;
       padding: #{$nav-list-item-height-sm * 0.25};
       color: $link-color;
+      flex-shrink: 0;
+      margin-right: 2px; // Add space for outline/border
 
       @include mq(md) {
         width: $nav-list-item-height;
@@ -103,6 +105,8 @@
       display: none;
       padding-left: $sp-3;
       list-style: none;
+      flex-basis: 100%;
+      width: 100%;
 
       .nav-list-item {
         position: relative;


### PR DESCRIPTION
This PR fixes #73 

This pull request updates the navigation styles in `_navigation.scss` to improve the layout and responsiveness of navigation items. The main changes focus on switching the navigation list items to use flexbox, enhancing alignment, wrapping, and sizing for better display across different screen sizes.

**Navigation layout improvements:**

* Changed `.nav-list-item` to use `display: flex`, enabled wrapping with `flex-wrap: wrap`, and aligned items vertically with `align-items: center` for improved layout and responsiveness.
* Added `flex: 1` to `.nav-list-link` to allow navigation links to grow and fill available space.
* Updated `.nav-list-expander` to remove absolute positioning, added `flex-shrink: 0` to prevent shrinking, and added `margin-right` for spacing, improving the alignment of expand/collapse icons.
* Set `flex-basis: 100%` and `width: 100%` on `.nav-list-child` to ensure child lists span the full width of their container, aiding in consistent nested navigation layout.