### PR TITLE
Fix search input sizing on mid-size

### DIFF
--- a/_includes/components/search_header.html
+++ b/_includes/components/search_header.html
@@ -1,11 +1,11 @@
 
 <div class="search">
   <form class="search-input-wrap" role="search">
-    <input type="text" id="search-input" name="q" class="search-input" placeholder="Search {{site.title}}" autocomplete="off">
     <label for="search-input" class="search-label">
       <span class="screen-reader-text">Search {{site.title}}</span>
       <svg viewBox="0 0 24 24" class="search-icon" aria-hidden="true"><use xlink:href="#svg-search"></use></svg>
     </label>
+    <input type="text" id="search-input" name="q" class="search-input" placeholder="Search {{site.title}}" autocomplete="off">
   </form>
   <div id="search-results" class="search-results"></div>
 </div>

--- a/_sass/components/_search.scss
+++ b/_sass/components/_search.scss
@@ -29,7 +29,6 @@
   transition: height linear #{$transition-duration * 0.5};
 
   @include mq(md) {
-    position: absolute;
     width: 100%;
     max-width: $search-results-width;
     height: 100% !important;
@@ -69,6 +68,7 @@
   display: flex;
   height: 100%;
   padding-left: $gutter-spacing-sm;
+  z-index: 20;
 
   @include mq(md) {
     padding-left: $gutter-spacing;


### PR DESCRIPTION
Also moves the search input label before the form, instead of after.

Fixes #194