### PR TITLE
236 Add tabindex=0 to the direct parent of a codeblock and a table

### DIFF
--- a/assets/js/wp-a11y-docs.js
+++ b/assets/js/wp-a11y-docs.js
@@ -564,8 +564,8 @@
         'div.highlighter-rouge > div.highlight, div.listingblock > div.content, figure.highlight, div.table-wrapper'
     );
 
-    scrollBlocks.forEach(codeBlock => {
-      codeBlock.tabIndex = 0;
+    scrollBlocks.forEach(scrollBlock => {
+      scrollBlock.tabIndex = 0;
     });
   });
 


### PR DESCRIPTION
Related issues: #236 and #237.  

Previews: 
- Table: https://wpaccessibility.org/pr-preview/pr-242/docs/topics/core/
- Code: https://wpaccessibility.org/pr-preview/pr-242/docs/topics/content/alt-text/
