### PR TITLE
Add border-style: solid, to override Safari’s default inset value

### DIFF
--- a/_sass/components/_search.scss
+++ b/_sass/components/_search.scss
@@ -69,6 +69,7 @@
   font-size: 1rem;
   border-width: 1px;
   border-color: var(--color-neutral-border-default);
+  border-style: solid; // overrides Safari default `inset` value
   border-left: none;
 
   @include mq(md) {


### PR DESCRIPTION
Related issue: #239 
Preview: https://wpaccessibility.org/pr-preview/pr-243/
