### PR TITLE
If an active list item contains a button, mark aria-expanded.

### DIFF
--- a/assets/js/wp-a11y-docs.js
+++ b/assets/js/wp-a11y-docs.js
@@ -528,6 +528,10 @@
       if (target) {
         target.classList.add('active');
         target.classList.toggle('active', true);
+        let button = target.querySelector( 'button' );
+        if ( button ) {
+          button.ariaExpanded = 'true';
+        }
         target = target.parentNode;
       }
     }


### PR DESCRIPTION
Fixes #238

Thank you for your contribution to the WP Accessibility Knowledge Base.

**Please note:**
Content committed without contacting the project leads @rianrietveld or @joedolson first, will not be reviewed.

The related issue number: #

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/contribute/).
- [x] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

