### PR TITLE
Differentiate table descriptions for search results

### DIFF
--- a/docs/topics/code/tables/index.md
+++ b/docs/topics/code/tables/index.md
@@ -1,15 +1,16 @@
 ---
-title: Tables
+title: Tables in code
 layout: default
 parent: Frontend code
+description: Tables in theme and plugin development
 nav_order: 5
 ---
 
 # Tables in theme and plugin development
 
 {: .callout .alert }
-**Alert:** This content will be reviewed and restructured.  
-Related issue on [GitHub #144 Topic Tables in theme and plugin development](https://github.com/wpaccessibility/wp-a11y-docs/issues/144).  
+**Alert:** This content will be reviewed and restructured.
+Related issue on [GitHub #144 Topic Tables in theme and plugin development](https://github.com/wpaccessibility/wp-a11y-docs/issues/144).
 
 Tables are the recommended way to display tabular data. Tabular data is any data that is best navigated in two dimensions: where there are relationships both vertically along columns and horizontally in rows. Tables are not a good idea for layout, however.
 

--- a/docs/topics/content/tables.md
+++ b/docs/topics/content/tables.md
@@ -2,13 +2,14 @@
 title: Tables
 layout: default
 parent: Content and images
+description: Tables in WordPress content
 nav_order: 5
 ---
 
 # Tables in the content
 
 {: .callout .alert }
-**Alert:** This content will be written.  
-Related issue on [GitHub #121 Topic Tables in the content](https://github.com/wpaccessibility/wp-a11y-docs/issues/121).  
+**Alert:** This content will be written.
+Related issue on [GitHub #121 Topic Tables in the content](https://github.com/wpaccessibility/wp-a11y-docs/issues/121).
 
 This content will be about how to add an accessible table in WordPres Admin and gives info about plugins to use, that can create accessible tables.


### PR DESCRIPTION
There are two pages on Tables, and the current page set up in the Jekyll theme is based on Title only, so if they have the same title, only one will ever be selected.

Fixes #256 

**Please note:**
Content committed without contacting the project leads @rianrietveld or @joedolson first, will not be reviewed.

The related issue number: #

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [ ] Your code builds clean without any errors or warnings while running `npm run test`.
- [ ] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

