### PR TITLE
add PDF resource

### DIFF
--- a/docs/topics/content/docs.md
+++ b/docs/topics/content/docs.md
@@ -35,7 +35,7 @@ The list of software which are able to export a PDF is quite long. In the export
 {: .callout .warning }
 **Warning**: Google Docs doesn’t support the export of a tagged and accessible PDF yet without any help of a plugin.
 
-### PDF Resources
+## Resources
 
 - [Defining PDF Accessibility](https://webaim.org/techniques/acrobat/) on WebAIM.
 - [Overview of PDF inaccessibility](https://developer.paciellogroup.com/blog/2017/02/pdf-inaccessibility/), by the Paciello Group.
@@ -44,4 +44,3 @@ The list of software which are able to export a PDF is quite long. In the export
 - [Create and verify PDF accessibility](https://helpx.adobe.com/ie/acrobat/using/create-verify-pdf-accessibility.html), by Acrobat Pro
 - [PDF/UA in a Nutshell (PDF)](https://pdfa.org/wp-content/until2016_uploads/2013/08/PDFUA-in-a-Nutshell-PDFUA.pdf), by the PDF association.
 - [Tagged PDF 508 help center](https://taggedpdf.com/508-pdf-help-center/), by Tagged PDF.
-


### PR DESCRIPTION
Adds resource [Techniques for Accessible PDF](https://pdfa.org/techniques-for-accessible-pdf/), by the PDF Association.
Props @macedvisioned
Preview: https://wpaccessibility.org/pr-preview/pr-263/docs/topics/content/docs/

Thank you for your contribution to the WP Accessibility Knowledge Base.

**Please note:**
Content committed without contacting the project leads @rianrietveld or @joedolson first, will not be reviewed.

The related issue number: #

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

