### PR TITLE
Fixing Typo: `sematics` should be `semantics`

### DIFF
--- a/docs/start/index.md
+++ b/docs/start/index.md
@@ -37,7 +37,7 @@ For developers web accessibility means a way of thinking often called progressiv
 - Let the JavaScript interact with the content.
 
 This division helps you create websites that are easier to maintain and update, and is considered to be a (c)lean approach to web development.
-[Standards and best practice]({{site.baseurl}}/docs/topics/) explains how to code with sematics and accessibility in mind.
+[Standards and best practice]({{site.baseurl}}/docs/topics/) explains how to code with semantics and accessibility in mind.
 
 ## In Summary
 


### PR DESCRIPTION
Fixing Typo: `sematics` should be `semantics` 
in `wpaccessibility / wp-a11y-docs / docs / start / index.md`

Thank you for your contribution to the WP Accessibility Knowledge Base.

The related issue number: #288

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [ ] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [ ] Your code builds clean without any errors or warnings while running `npm run test`.
- [ ] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

