### PR TITLE
add disclaimer

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -32,7 +32,7 @@
 
       </div>
 
-      <p class="text-small"><strong>Disclaimer</strong>: This documentation is designed to help the WordPress community understand and implement accessible practices. It is not a replacement of the official Web Content Accessibility Guidelines. Please read the <a href="{{site.baseurl}}/docs/about/disclaimer/"> full disclaimer</a>.</p>
+      <p class="text-small"><strong>Disclaimer</strong>: This documentation is intended to help the WordPress community understand and implement accessible practices. It is not a replacement for the official Web Content Accessibility Guidelines. Please read the <a href="{{site.baseurl}}/docs/about/disclaimer/"> full disclaimer</a>.</p>
 
       <p>
         <span aria-hidden="true">&uarr;</span>

--- a/docs/about/disclaimer.md
+++ b/docs/about/disclaimer.md
@@ -1,6 +1,6 @@
 ---
 title: Disclaimer
-description: This documentation is designed to help the WordPress community understand and implement accessible practices. It is not a replacement of the official Web Content Accessibility Guidelines.
+description: This documentation is intended to help the WordPress community understand and implement accessible practices. It is not a replacement for the official Web Content Accessibility Guidelines.
 layout: default
 parent: About this documentation
 nav_order: 8
@@ -8,13 +8,13 @@ nav_order: 8
 
 # Disclaimer
 
-This documentation is designed to help the WordPress community understand and implement accessible practices and has no legal status. It is not a replacement of the official Web Content Accessibility Guidelines (WCAG). 
+This documentation is intended to help the WordPress community understand and implement accessible practices and has no legal status. It is not a replacement for the official Web Content Accessibility Guidelines (WCAG). 
 
 When relevant in the documentation, we add links to the official WCAG documentation pointing to the related guidelines and success criteria.
 
 {: .info .callout }
 **Please note**: This documentation is not a substitute for the official WCAG guidelines published by the Web Accessibility Initiative (WAI) by the Word Wide Web Consortium (W3C), nor is it intended for legal analysis, reference, or formal compliance audits or reports.
 
-If you are conducting an accessibility review, an accessibility audit, or research legal requirements, please refer directly to the [official WCAG documentation](https://www.w3.org/WAI/standards-guidelines/wcag/) by the W3C.
+If you are conducting an accessibility review, an accessibility audit, or researching legal requirements, please refer directly to the [official WCAG documentation](https://www.w3.org/WAI/standards-guidelines/wcag/) by the W3C.
 
 If you find documentation on this website that is in conflict with WCAG 2.2 AA, please let us know by  [contacting the team]({{site.baseurl}}//docs/about/contact/).


### PR DESCRIPTION
Adds a disclaimer in the footer of each page and in a dedicated page.

Preview: https://wpaccessibility.org/pr-preview/pr-292/docs/about/disclaimer/

The related issue number: #265 

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [x] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

