### PR TITLE
Adds meta data to pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,4 @@ gem "jekyll-sitemap", group: :jekyll_plugins
 gem "jekyll-paginate", group: :jekyll_plugins
 gem "jekyll-sass-converter", "~> 3.1.0"
 gem "html-proofer", "~> 5.0", :group => :development
+gem "jekyll-last-modified-at", group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
       octokit (>= 4, < 7, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.2)
+      jekyll (>= 3.7, < 5.0)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
@@ -169,6 +171,7 @@ DEPENDENCIES
   html-proofer (~> 5.0)
   jekyll-github-metadata (>= 2.15)
   jekyll-include-cache
+  jekyll-last-modified-at
   jekyll-paginate
   jekyll-sass-converter (~> 3.1.0)
   jekyll-sitemap

--- a/_config.yml
+++ b/_config.yml
@@ -112,14 +112,12 @@ liquid:
   error_mode: strict
   strict_filters: true
 
-# Footer last edited timestamp
-last_edit_timestamp: true # show or hide edit time - page must have `last_modified_date` defined in the frontmatter
-last_edit_time_format: "%b %e %Y at %I:%M %p" # uses ruby's time format: https://ruby-doc.org/stdlib-2.7.0/libdoc/time/rdoc/Time.html
-
-# Footer "Edit this page on GitHub" link text
+# Meta "Edit this page on GitHub" link text
 gh_edit_link: true # show or hide edit this page link
-gh_edit_link_text: "View this page on GitHub"
+gh_edit_link_text: "Improve it on GitHub"
 gh_edit_repository: "https://github.com/wpaccessibility/wp-a11y-docs" # the github URL for your repo
+gh_edit_branch: "main" # the branch that your docs is served from
+gh_edit_view_mode: "tree" # "tree" or "edit" if you want the user to jump into the editor immediately
 
 # Color scheme currently only supports "dark", "light"/nil (default), or a custom scheme that you define
 color_scheme: nil
@@ -147,6 +145,7 @@ plugins:
   - jekyll-sitemap
   - jekyll-sass-converter
   - jekyll-paginate
+  - jekyll-last-modified-at
 
 kramdown:
   syntax_highlighter_opts:

--- a/_includes/components/meta.html
+++ b/_includes/components/meta.html
@@ -1,0 +1,38 @@
+<section aria-label="Meta data of this page" class="meta">
+
+    <ul>
+
+        {% if page.date_created %}
+        <li><span>First published:</span> {{ page.date_created }}</li>
+        {% else %}
+        <li><span>First published:</span> October 10, 2025</li>
+        {% endif %}
+
+        <li><span>Last updated:</span> {% last_modified_at %B %d, %Y %}</li>
+
+        {% if
+        site.gh_edit_link and
+        site.gh_edit_link_text and
+        site.gh_edit_repository and
+        site.gh_edit_branch and
+        site.gh_edit_view_mode
+        %}
+
+        <li><span>Edit article:</span>
+        <a href="{{ site.gh_edit_repository }}/{{ site.gh_edit_view_mode }}/{{ site.gh_edit_branch }}{% if site.gh_edit_source %}/{{ site.gh_edit_source }}{% endif %}{% if page.collection and site.collections_dir %}/{{ site.collections_dir }}{% endif %}/{{ page.path }}" id="edit-this-page">{{ site.gh_edit_link_text }}</a>
+        </li>
+
+        {% endif %}
+
+    </ul>
+
+    {% if page.contributors %}
+    <p><span>Contributors:</span>
+            {% for item in page.contributors %}
+                {{ item }},
+            {% endfor %}
+            read <a href="{{site.baseurl}}/docs/about/contribute/">how to contribute to this documentation</a>.
+    </p>
+    {% endif %}
+
+</section>

--- a/_includes/components/meta.html
+++ b/_includes/components/meta.html
@@ -30,10 +30,8 @@
     <p><span>Contributors:</span>
             {% for item in page.contributors %}
                 {{ item }}
-                {%- if forloop.index < forloop.length -%}
-                    ,
-                {% else %}
-                    .
+                {%- if forloop.index < forloop.length -%},
+                {% else %}.
                 {% endif %}
             {% endfor %}
     </p>

--- a/_includes/components/meta.html
+++ b/_includes/components/meta.html
@@ -1,4 +1,4 @@
-<section aria-label="Meta data of this page" class="meta">
+<section aria-label="Page meta data" class="meta">
 
     <ul>
 
@@ -29,10 +29,16 @@
     {% if page.contributors %}
     <p><span>Contributors:</span>
             {% for item in page.contributors %}
-                {{ item }},
+                {{ item }}
+                {%- if forloop.index < forloop.length -%}
+                    ,
+                {% else %}
+                    .
+                {% endif %}
             {% endfor %}
-            read <a href="{{site.baseurl}}/docs/about/contribute/">how to contribute to this documentation</a>.
     </p>
     {% endif %}
+    <p>Read <a href="{{site.baseurl}}/docs/about/contribute/">how to contribute to this documentation</a>.</p>
+
 
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,15 +30,16 @@ layout: table_wrappers
 
           {{ content }}
 
-          {% include components/meta.html %}
-
           {% if page.has_toc != false %}
             {% include components/children_nav.html %}
           {% endif %}
 
+          {% include components/meta.html %}
+
         </main>
 
         {% include components/footer.html %}
+
       </div>
     </div>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,6 +30,8 @@ layout: table_wrappers
 
           {{ content }}
 
+          {% include components/meta.html %}
+
           {% if page.has_toc != false %}
             {% include components/children_nav.html %}
           {% endif %}

--- a/_sass/components/_index.scss
+++ b/_sass/components/_index.scss
@@ -5,6 +5,7 @@
 @forward "callouts";
 @forward "footer";
 @forward "labels";
+@forward "meta";
 @forward "next-prev";
 @forward "search";
 @forward "skiptomain";

--- a/_sass/components/_meta.scss
+++ b/_sass/components/_meta.scss
@@ -12,6 +12,7 @@
   ul {
     display: flex;
     padding-left: 0;
+    gap: 2em;
 
     ul {
       display: block;
@@ -19,7 +20,7 @@
 
     li {
       list-style: none;
-      padding-right: 2em;
+      padding: 0;
     }
 
   }

--- a/_sass/components/_meta.scss
+++ b/_sass/components/_meta.scss
@@ -1,0 +1,32 @@
+@use "../abstracts/variables" as *;
+@use "../base/colors" as *;
+@use "../abstracts/mixins" as *;
+
+@use "sass:color";
+
+.meta {
+  padding-top: 1.25em;
+  border-top: $border $border-color;
+  font-size: var(--text-font-size-sm);
+
+  ul {
+    display: flex;
+    padding-left: 0;
+
+    ul {
+      display: block;
+    }
+
+    li {
+      list-style: none;
+      padding-right: 2em;
+    }
+
+  }
+
+  span {
+    display: block;
+    font-weight: 600;
+  }
+
+}

--- a/docs/about/contact/index.md
+++ b/docs/about/contact/index.md
@@ -6,7 +6,7 @@ nav_order: 4
 description: Contact the WordPress Accessibility Team.
 ---
 
-# Contact the Contact the WordPress Accessibility Team.
+# Contact the WordPress Accessibility Team.
 
 There are several ways to contact us:
 - [Open an issue](https://github.com/wpaccessibility/wp-a11y-docs/issues) on GitHub with your question.

--- a/docs/topics/content/alt-text/index.md
+++ b/docs/topics/content/alt-text/index.md
@@ -4,6 +4,10 @@ layout: default
 parent: Content and images
 description: The alt attribute (alt text) is used to provide an alternative to the image for users who can’t see it.
 nav_order: 2
+contributors:
+  - Rian Rietveld
+  - Joe Dolson
+  - Gary Jones
 ---
 
 # Alternative text for images in the content

--- a/docs/topics/content/headings/index.md
+++ b/docs/topics/content/headings/index.md
@@ -4,6 +4,10 @@ layout: default
 parent: Content and images
 description: A heading should simply and concisely describe the content that follows.
 nav_order: 3
+contributors:
+  - Rian Rietveld
+  - Joe Dolson
+  - Gary Jones
 ---
 
 # Using headings in the content

--- a/docs/topics/content/multiple-ways-contact.md
+++ b/docs/topics/content/multiple-ways-contact.md
@@ -4,6 +4,9 @@ layout: default
 parent: Content and images
 description: It’s better to offer multiple ways to get in touch, so people can choose what suits them. Think about your visitors first, not just what’s easiest for you.
 nav_order: 4
+contributors:
+  - Rian Rietveld
+  - Joe Dolson
 ---
 
 # Offer multiple ways to get in touch

--- a/docs/topics/theme-guidelines/accessibility-statement.md
+++ b/docs/topics/theme-guidelines/accessibility-statement.md
@@ -4,6 +4,9 @@ layout: default
 parent: Theme accessibility guidelines
 nav_order: 16
 description: Accessibility Statement requirements for Accessibility-ready themes
+contributors:
+  - Amber Hinds 
+  - Joe Dolson
 ---
 
 # Accessibility statement


### PR DESCRIPTION
The related issue number: #35
Preview: https://wpaccessibility.org/pr-preview/pr-310/docs/topics/content/headings/

First published and Contributors are added manualy in the front matter.
Last updated and Edit article are generated with Jeckyll gems.

If no First published is provided, the build date of the site is shown: October 10, 2025.

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [x] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

