### PR TITLE
Update pages about links for content and for design

### DIFF
--- a/docs/start/business/personas.md
+++ b/docs/start/business/personas.md
@@ -20,7 +20,7 @@ For example: did you ever watch a video in a full, noisy train, and you forgot y
 - Carel has Parkinson’s disease. His hands are not steady enough to mouse-click on a link with tiny text.
 - Louis uses a screen reader. He struggles to understand a page’s content because its markup has no logical heading structure.
 - Kaia is blind. Links that are an image or an icon font, with no link text, are effectively invisible to her.
-- Carlos is color blind. He can’t distinguish the red links from the black text.
+- Carlos is color-blind. He can’t distinguish the red links from the black text.
 - Ray is in his 60s. His eyesight has degraded. He can no longer read small grey text on top a darker grey background.
 - Braiden has ADD (Attention Deficit Disorder). A distracting animation in the sidebar, with no user-control for stopping, prevents her from focusing on the page content.
 - Alyssa is deaf. A video without subtitles is unusable to her.

--- a/docs/testing/checklists/design.md
+++ b/docs/testing/checklists/design.md
@@ -25,9 +25,9 @@ There are many tools to calculate this easily, see [Color contrast checkers](htt
 ## Color Contrast
 
 - [contrastchecker.com](http://contrastchecker.com/) (Online) — checks foreground/background contrast levels and also gives information on the accessibility levels of the contrast
-- [Color Contrast Analyser](http://www.paciellogroup.com/resources/contrastAnalyser) (Windows and OSX)– checks foreground/background contrast levels and preview designs as they might be seen by color blind users.
-- [Sim Daltonism](http://michelf.ca/projects/sim-daltonism/) — a color blindness simulator for Mac OS X.
-- [Colorblind Web Page Filter](https://www.toptal.com/designers/colorfilter) — apply a color blindness emulating filter to a web page.
+- [Color Contrast Analyser](http://www.paciellogroup.com/resources/contrastAnalyser) (Windows and OSX)– checks foreground/background contrast levels and preview designs as they might be seen by color-blind users.
+- [Sim Daltonism](http://michelf.ca/projects/sim-daltonism/) — a color-blindness simulator for Mac OS X.
+- [Colorblind Web Page Filter](https://www.toptal.com/designers/colorfilter) — apply a color-blindness emulating filter to a web page.
 - [Color Palette Accessibility Evaluator](http://accessibility.oit.ncsu.edu/tools/color-contrast/index.php) — analyze color combinations for conformance to accessibility guidelines.
 
 
@@ -40,7 +40,7 @@ There are many tools to calculate this easily, see [Color contrast checkers](htt
 ### Color blindness check tools:
 
 - Look at your design only in grey scale colors, remove all color. Can you still understand it?
-- [Sim Daltonism](https://michelf.ca/projects/sim-daltonism/) tool for color blindness check.
+- [Sim Daltonism](https://michelf.ca/projects/sim-daltonism/) tool for color-blindness check.
 - [Coblis](http://www.color-blindness.com/coblis-color-blindness-simulator/) – Color Blindness Simulator
 
 ## Not by icon alone

--- a/docs/testing/checklists/design.md
+++ b/docs/testing/checklists/design.md
@@ -4,6 +4,9 @@ layout: default
 parent: Checklists
 description: Learn about some design checks you can do to enhance accessibility.
 nav_order: 4
+contributors:
+  - Joe Dolson
+  - Rian Rietveld
 ---
 
 
@@ -28,7 +31,7 @@ There are many tools to calculate this easily, see [Color contrast checkers](htt
 - [Color Contrast Analyser](http://www.paciellogroup.com/resources/contrastAnalyser) (Windows and OSX)– checks foreground/background contrast levels and preview designs as they might be seen by color-blind users.
 - [Sim Daltonism](http://michelf.ca/projects/sim-daltonism/) — a color-blindness simulator for Mac OS X.
 - [Colorblind Web Page Filter](https://www.toptal.com/designers/colorfilter) — apply a color-blindness emulating filter to a web page.
-- [Color Palette Accessibility Evaluator](http://accessibility.oit.ncsu.edu/tools/color-contrast/index.php) — analyze color combinations for conformance to accessibility guidelines.
+- [Accessible color palette generator](https://venngage.com/tools/accessible-color-palette-generator) - Tool to generate accessible color palettes.
 
 
 ## Not by color alone

--- a/docs/topics/content/links/index.md
+++ b/docs/topics/content/links/index.md
@@ -9,6 +9,3 @@ nav_order: 3
 # Web links
 
 These pages in this section inform you about what is important to create accessible links and how to write proper link texts for the web.
-
-
-

--- a/docs/topics/content/links/link-destinations.md
+++ b/docs/topics/content/links/link-destinations.md
@@ -25,19 +25,21 @@ Not all screen readers alert users when a new window or tab has opened and for t
 
 This can be prevented by not checking “open link in a new target” on links, so they don’t trigger new windows or tabs to open.
 
-### But what if you insist?
-
 If you absolutely need to open a link in a new window, you need to tell your visitor in the link text.
 
-{: .example }
-For example: I love cats, so I watch [cat videos (opens in a new tab)](#) on YouTube.
+{: .callout .example }
+For example:     
+I love cats, so I watch [cat videos (opens in a new tab)](#) on YouTube.
+
 
 ## Link to a document
 
 If the link opens a document, add the format of the document in the link text.
 
-{: .example }
-You can [download the manual as PDF](#).
+{: .callout .example }
+For example:    
+You can [download the manual as PDF](#).    
+Please [download our terms (PDF, 3Mb)](#).
 
 ## Resources
 
@@ -47,8 +49,12 @@ By adding meaningful link text, you meet WCAG success criteria
 - [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context) (level A).
 - [2.4.9 Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only) (level **AAA**).
 - [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/quickref/#label-in-name) (level A).
+- [3.2.5 Change on Request](https://www.w3.org/WAI/WCAG22/quickref/#change-on-request) (level **AAA)**.
+
+
 
 ## Other resources
 
-
+- [Link Targets and 3.2.5](https://adrianroselli.com/2020/02/link-targets-and-3-2-5.html), by Adrian Roselli.
+- [Opening new windows and tabs from a link only when necessary](https://www.w3.org/WAI/WCAG21/Techniques/general/G200), by the W3C.
 - [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-destinations.md
+++ b/docs/topics/content/links/link-destinations.md
@@ -51,10 +51,9 @@ By adding meaningful link text, you meet WCAG success criteria
 - [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/quickref/#label-in-name) (level A).
 - [3.2.5 Change on Request](https://www.w3.org/WAI/WCAG22/quickref/#change-on-request) (level **AAA)**.
 
-
-
-## Other resources
+### Other resources
 
 - [Link Targets and 3.2.5](https://adrianroselli.com/2020/02/link-targets-and-3-2-5.html), by Adrian Roselli.
+[Designing Better Links UX](https://smart-interface-design-patterns.com/articles/links-ux/) on Smart Interface Design Patterns.
 - [Opening new windows and tabs from a link only when necessary](https://www.w3.org/WAI/WCAG21/Techniques/general/G200), by the W3C.
 - [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-destinations.md
+++ b/docs/topics/content/links/link-destinations.md
@@ -4,6 +4,9 @@ layout: default
 parent: Links
 description: Always tell a visitor what to expect when selecting a link.
 nav_order: 4
+contributors:
+  - Joe Dolson
+  - Rian Rietveld
 ---
 
 
@@ -36,10 +39,16 @@ If the link opens a document, add the format of the document in the link text.
 {: .example }
 You can [download the manual as PDF](#).
 
-# Resources
+## Resources
 
 ### Related WCAG Success Criteria for links
 
 By adding meaningful link text, you meet WCAG success criteria
 - [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context) (level A).
+- [2.4.9 Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only) (level **AAA**).
 - [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/quickref/#label-in-name) (level A).
+
+## Other resources
+
+
+- [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-image.md
+++ b/docs/topics/content/links/link-image.md
@@ -11,9 +11,9 @@ contributors:
 
 # Images as links
 
-For linked images, the `alt` attribute (the alternative text) can be used as the link text. Screen readers will announce the alt text when the link gets focus.
+For linked images, the `alt` attribute (the alternative text) is used as the link text. Screen readers will announce the alt text when the link gets focus.
 
-But: if the alt attribute describes the image, the link text will be the description of the image, which is unlikely to clearly communicate the link purpose.
+If the alt attribute describes the image, the link text will be the description of the image, which is unlikely to clearly communicate the link purpose.
 
 The post [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/h-embedding-an-image-in-a-link) by The A11Y Collective gives an example of this.
 
@@ -22,14 +22,14 @@ The post [Creating the perfect link](https://www.a11y-collective.com/blog/the-pe
 
 So the proper way to use an image as a link is to describe the link destination in the alt text. If the image links to a post about the Accessibility Team’s handbook, add the alternative text “Accessibility Team Handbook”.
 
-It is not necessary to ever use the word ‘link’ or 'this link goes to' in your alt text; that will already be sufficient announced by the screen reader.
+It is not helpful to use the word ‘link’ or 'this link goes to' in your alt text; that will already be announced by the screen reader.
 
 {: .callout .dont }
-**Don't**: leave the alt text out for an image that is used as link.    
+**Don't**: omit alt text for an image that is used as link.    
 
 <a href="{{site.baseurl}}"><img src="{{site.baseurl}}/assets/images/logo-wa11ypuu.png" alt=""></a>
 
-The screen reader VoiceOver announces this as: "**Link, link image**". So there is no info at all about where the link leads to.
+The screen reader VoiceOver announces this as: "**Link, link image**". So there is no information about where the link leads.
 
 {: .callout .do }
 **Do**: use the alt text as link text.

--- a/docs/topics/content/links/link-image.md
+++ b/docs/topics/content/links/link-image.md
@@ -11,8 +11,9 @@ contributors:
 
 # Images as links
 
-For linked images, the `alt` attribute (the alternative text) can be used as the link text.
-If the alt attribute describes the image: the link text will be the description of the image, which is unlikely to clearly communicate the link purpose.
+For linked images, the `alt` attribute (the alternative text) can be used as the link text. Screen readers will announce the alt text when the link gets focus.
+
+But: if the alt attribute describes the image, the link text will be the description of the image, which is unlikely to clearly communicate the link purpose.
 
 The post [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/h-embedding-an-image-in-a-link) by The A11Y Collective gives an example of this.
 
@@ -22,6 +23,23 @@ The post [Creating the perfect link](https://www.a11y-collective.com/blog/the-pe
 So the proper way to use an image as a link is to describe the link destination in the alt text. If the image links to a post about the Accessibility Team’s handbook, add the alternative text “Accessibility Team Handbook”.
 
 It is not necessary to ever use the word ‘link’ or 'this link goes to' in your alt text; that will already be sufficient announced by the screen reader.
+
+{: .callout .dont }
+**Don't**: leave the alt text out for an image that is used as link.    
+
+<a href="{{site.baseurl}}"><img src="{{site.baseurl}}/assets/images/logo-wa11ypuu.png" alt=""></a>
+
+The screen reader VoiceOver announces this as: "**Link, link image**". So there is no info at all about where the link leads to.
+
+{: .callout .do }
+**Do**: use the alt text as link text.
+
+With alt text:      
+<a href="{{site.baseurl}}"><img src="{{site.baseurl}}/assets/images/logo-wa11ypuu.png" alt="WP Accessibility Knowledge Base"></a>  
+
+The screen reader VoiceOver announces this as: "**Link, image, WP Accessibility Knowledge Base**". The user now knows it's a link with an image, and the link leads to the WP Accessibility Knowledge Base.
+
+Read [Alternative text for images in the content]({{site.baseurl}}/docs/topics/content/alt-text/) about how to add a custom alt text on an image in WordPress.
 
 ## Resources
 

--- a/docs/topics/content/links/link-image.md
+++ b/docs/topics/content/links/link-image.md
@@ -4,6 +4,9 @@ layout: default
 parent: Links
 description: For linked images, the alt attribute (the alternative text) can be used as the link text.
 nav_order: 3
+contributors:
+  - Joe Dolson
+  - Rian Rietveld
 ---
 
 # Images as links
@@ -27,4 +30,9 @@ It is not necessary to ever use the word ‘link’ or 'this link goes to' in yo
 By giving a meaningful image proper alternative text, you meet WCAG success criteria
 - [1.1.1 Non-text Content](https://www.w3.org/WAI/WCAG22/quickref/#non-text-content) (level A).
 - [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context) (level A).
+- [2.4.9 Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only) (level **AAA**).
 - [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/quickref/#label-in-name) (level A).
+
+### Other resources
+
+- [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -23,11 +23,11 @@ It also makes your text easier to scan visually, so that sighted users can more 
 <figcaption>Descriptive, meaningful link text in the Apple VoiceOver link list.</figcaption>
 </figure>
 
-Saar Twito explains the concept of a good link text comprehensive in [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide).
+Saar Twito comprehensively explains the concept of good link text in [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide).
 
 ## Make links texts descriptive
 
-Avoid meaningless link text like: click here, download, info, more, here, this.
+Avoid meaningless link text like: "click here", "download", "info", "more", "here", "this" or other similarly empty phrases.
 
 With these types of links, users have to read the whole sentence to understand the purpose of the link. This makes your content less browsable, and harder to engage with. Screen reader users cannot navigate by links, because those links are not useful without additional context.
 
@@ -37,11 +37,11 @@ With these types of links, users have to read the whole sentence to understand t
 </figure>
 
 {: .callout .dont }
-**Don't**: write poor quality (non-descriptive) link texts:        
+**Don't**: write poor quality (non-descriptive) link text:        
 If you are interested in our work, [click here](#dummy-link) to subscribe to our newsletter. You can [download](#dummy-link) the manual of the espresso machine, or contact us for more [info](#dummy-link).
 
 {: .callout .do }
-**Do**: write helpful (descriptive) link texts:  
+**Do**: write helpful (descriptive) link text:  
 [Subscribe to our newsletter](#dummy-link) if you are interested in our work. You can download the [manual as a PDF]((#dummy-link) ) of the espresso machine, or [contact us](#dummy-link) for more info.
 
 ## Avoid fancy character combinations in your links
@@ -53,7 +53,7 @@ Avoid for example in your link texts:
 - Leetspeak, example: m8ts
 - Excessive use of Emoji
 
-ASCII art is invariably meaningless to screen reader users. Emoticons may occasionally be interpretable, but are confusing and difficult to understand. “Leetspeak” is unpronounceable, and creates difficult in comprehension. Emoji are independently accessible; they do have text alternatives. However, a large number of emoji can make the text effectively impossible to comprehend.
+ASCII art is invariably meaningless to screen reader users. Emoticons are occasionally interpretable, but are confusing and difficult to understand. “Leetspeak” is unpronounceable, and creates difficulties for comprehension. Emoji are independently accessible; they do have text alternatives. However, a large number of emoji can make the text effectively impossible to comprehend.
 
 {: .callout .dont }
 **Don't**: overload your link text with emoji.     
@@ -85,14 +85,14 @@ Some URLs are highly readable, such as “wordpress.org”. Others are almost im
 We keep track of all the issues in: [https://github.com/wpaccessibility/wp-a11y-docs/issues/85](https://github.com/wpaccessibility/wp-a11y-docs/issues/85).
 
 {: .callout .do }
-**Do**: write a meaningful and readable link text:    
+**Do**: write meaningful and readable link text:    
 We keep track of all the issues in: [Content pages: create or review or rewrite](https://github.com/wpaccessibility/wp-a11y-docs/issues/85).
 
 ## Avoid the title attribute on links
 
 You should not use the title attribute on links, because the title attribute is only available for sighted users on desktop using a mouse. Other users will miss that information. 
 
-In addition, screen readers announce the title attribute inconsistently. You must be sure that all users get the information they need and the title attribute doesn’t provide that.
+In addition, screen readers announce the title attribute inconsistently. You must be sure that all users get the information they need and the title attribute doesn’t provide that certainty.
 
 {: .callout .dont }
 **Don't**: use a title attribute on links.   
@@ -100,7 +100,7 @@ In addition, screen readers announce the title attribute inconsistently. You mus
 <a href="#" title="download the PDF">manual</a>
 
 {: .callout .do }
-**Do**: add all into in the link text, so everyone had the dame information and the information is always visible.  
+**Do**: add all info in the link text, so everyone has the same information and it is always visible.  
 `<a href="some-url">download the manual as PDF</a>`    
 <a href="#">download the manual as PDF</a>
 

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -55,21 +55,26 @@ Avoid for example in your link texts:
 
 ASCII art is invariably meaningless to screen reader users. Emoticons may occasionally be interpretable, but are confusing and difficult to understand. “Leetspeak” is unpronounceable, and creates difficult in comprehension. Emoji are independently accessible; they do have text alternatives. However, a large number of emoji can make the text effectively impossible to comprehend.
 
+{: .callout .dont }
+**Don't**: overload your link text with emoji.     
+[I 👏 approve 👏 this 👏 message 👏 ](#).
+
+{: .callout .do }
+**Do**: keep your link text clean, to the point and simple.  
+[I approve this message](#) 👏 .
+
+
 ## Avoid writing links in all caps
 
 Sequences of all capital letters are harder to read for people with dyslexia, screen readers may interpret short capitalized words as abbreviations, and read the words out character by character. This is also true if text is capitalized using CSS.
 
 {: .callout .dont }
-**Don't**: use all caps as link text.   
-`<a href="some-url">ACT NOW</a>`    
-<a href="#">ACT NOW</a>
+**Don't**: use all caps as link text.      
+<a href="#">ACT NOW</a>.
 
 {: .callout .do }
-**Do**: use sentence case or title case as link text.   
-`<a href="some-url">Act now</a>`     
-<a href="#">Act now</a>     
-`<a href="some-url">Act Now</a>`     
-<a href="#">Act Now</a>   
+**Do**: use sentence case or title case as link text.    
+<a href="#">Act now</a> or <a href="#">Act Now</a>.   
 
 ## Avoid using complete URLs as link text
 
@@ -95,7 +100,7 @@ In addition, screen readers announce the title attribute inconsistently. You mus
 <a href="#" title="download the PDF">manual</a>
 
 {: .callout .do }
-**Do**: add all into in the link text, so everyone had the dame information and the inforlation is aways visible.  
+**Do**: add all into in the link text, so everyone had the dame information and the information is always visible.  
 `<a href="some-url">download the manual as PDF</a>`    
 <a href="#">download the manual as PDF</a>
 

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -4,6 +4,9 @@ layout: default
 parent: Links
 description: A link text should describe the resource that it links to.
 nav_order: 2
+contributors:
+  - Joe Dolson
+  - Rian Rietveld
 ---
 
 # Write meaningful link text
@@ -20,7 +23,9 @@ It also makes your text easier to scan visually, so that sighted users can more 
 <figcaption>Descriptive, meaningful link text in the Apple VoiceOver link list.</figcaption>
 </figure>
 
-### Make links texts descriptive
+Saar Twito explains the concept of a good link text comprehensive in [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide).
+
+## Make links texts descriptive
 
 Avoid meaningless link text like: click here, download, info, more, here, this.
 
@@ -32,11 +37,11 @@ With these types of links, users have to read the whole sentence to understand t
 </figure>
 
 {: .callout .dont }
-Poor qualify (non-descriptive) link texts:
+**Don't**: write poor quality (non-descriptive) link texts:        
 If you are interested in our work, [click here](#dummy-link) to subscribe to our newsletter. You can [download](#dummy-link) the manual of the espresso machine, or contact us for more [info](#dummy-link).
 
 {: .callout .do }
-Helpful (descriptive) link texts:
+**Do**: write helpful (descriptive) link texts:  
 [Subscribe to our newsletter](#dummy-link) if you are interested in our work. You can download the [manual as a PDF]((#dummy-link) ) of the espresso machine, or [contact us](#dummy-link) for more info.
 
 ## Avoid fancy character combinations in your links
@@ -50,30 +55,62 @@ Avoid for example in your link texts:
 
 ASCII art is invariably meaningless to screen reader users. Emoticons may occasionally be interpretable, but are confusing and difficult to understand. “Leetspeak” is unpronounceable, and creates difficult in comprehension. Emoji are independently accessible; they do have text alternatives. However, a large number of emoji can make the text effectively impossible to comprehend.
 
-### Avoid writing links in all caps
+## Avoid writing links in all caps
 
 Sequences of all capital letters are harder to read for people with dyslexia, screen readers may interpret short capitalized words as abbreviations, and read the words out character by character. This is also true if text is capitalized using CSS.
 
-### Avoid using complete URLs as link text
+{: .callout .dont }
+**Don't**: use all caps as link text.   
+`<a href="some-url">ACT NOW</a>`    
+<a href="#">ACT NOW</a>
+
+{: .callout .do }
+**Do**: use sentence case or title case as link text.   
+`<a href="some-url">Act now</a>`     
+<a href="#">Act now</a>     
+`<a href="some-url">Act Now</a>`     
+<a href="#">Act Now</a>   
+
+## Avoid using complete URLs as link text
 
 Some URLs are highly readable, such as “wordpress.org”. Others are almost impossible to parse as language. In most cases, you should avoid using a URL as the visible link text. If you are explicitly referring to a web address, keep it short: [wordpress.org](https://www.wordpress.org) instead of [https://www.wordpress.org](https://www.wordpress.org).
 
 {: .callout .dont }
-Poor quality (non-descriptive) link texts:
-If you are interested in our work, [click here](#dummy-link) to subscribe to our newsletter. You can [download](#dummy-link) the manual of the espresso machine, or contact us for more [info](#dummy-link).
+**Don't**: use a url as link text:    
+We keep track of all the issues in: [https://github.com/wpaccessibility/wp-a11y-docs/issues/85](https://github.com/wpaccessibility/wp-a11y-docs/issues/85).
 
 {: .callout .do }
-Helpful (descriptive) link texts:
-[Subscribe to our newsletter]((#dummy-link)) if you are interested in our work. You can download the [manual as a PDF]((#dummy-link)) of the espresso machine, or [contact us](#dummy-link) for more info.
+**Do**: write a meaningful and readable link text:    
+We keep track of all the issues in: [Content pages: create or review or rewrite](https://github.com/wpaccessibility/wp-a11y-docs/issues/85).
 
 ## Avoid the title attribute on links
 
-You should not use the title attribute on links, because the title attribute is only available for sighted users on desktop using a mouse. Other users will miss that information. In addition, screen readers announce the title attribute inconsistently. You must be sure that all users get the information they need and the title attribute doesn’t provide that.
+You should not use the title attribute on links, because the title attribute is only available for sighted users on desktop using a mouse. Other users will miss that information. 
 
-# Resources
+In addition, screen readers announce the title attribute inconsistently. You must be sure that all users get the information they need and the title attribute doesn’t provide that.
+
+{: .callout .dont }
+**Don't**: use a title attribute on links.   
+`<a href="some-url" title="download the PDF">manual</a>`    
+<a href="#" title="download the PDF">manual</a>
+
+{: .callout .do }
+**Do**: add all into in the link text, so everyone had the dame information and the inforlation is aways visible.  
+`<a href="some-url">download the manual as PDF</a>`    
+<a href="#">download the manual as PDF</a>
+
+## Resources
 
 ### Related WCAG Success Criteria for links
 
 By giving a meaningful link text, you meet WCAG success criteria
 - [2.4.4 Link Purpose (In Context)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-in-context) (level A).
+- [2.4.9 Link Purpose (Link Only)](https://www.w3.org/WAI/WCAG22/quickref/#link-purpose-link-only) (level **AAA**).
 - [2.5.3 Label in Name](https://www.w3.org/WAI/WCAG22/quickref/#label-in-name) (level A).
+
+### Other resources
+
+- [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide) by Saar Twito.
+- [Writing for Web Accessibility ](https://www.w3.org/WAI/tips/writing/), by the W3C.
+- [Links and Hypertext](https://webaim.org/techniques/hypertext/hypertext_links), by WebAIM
+- [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -116,6 +116,7 @@ By giving a meaningful link text, you meet WCAG success criteria
 ### Other resources
 
 - [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide) by Saar Twito.
+- [Designing Better Links UX](https://smart-interface-design-patterns.com/articles/links-ux/) on Smart Interface Design Patterns.
 - [Writing for Web Accessibility ](https://www.w3.org/WAI/tips/writing/), by the W3C.
 - [Links and Hypertext](https://webaim.org/techniques/hypertext/link_text), by WebAIM
 - [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -117,5 +117,5 @@ By giving a meaningful link text, you meet WCAG success criteria
 
 - [Descriptive Link Text: The Art of Clear Digital Signposting](https://www.greadme.com/blog/accessibility/how-to-write-descriptive-link-text-complete-guide) by Saar Twito.
 - [Writing for Web Accessibility ](https://www.w3.org/WAI/tips/writing/), by the W3C.
-- [Links and Hypertext](https://webaim.org/techniques/hypertext/hypertext_links), by WebAIM
+- [Links and Hypertext](https://webaim.org/techniques/hypertext/link_text), by WebAIM
 - [Creating the perfect link](https://www.a11y-collective.com/blog/the-perfect-link/), by The A11Y Collective.

--- a/docs/topics/design/color/use-of-color.md
+++ b/docs/topics/design/color/use-of-color.md
@@ -29,7 +29,7 @@ Use additional styling to indicate types of information including a change of sh
 
 Use symbols and colors in graphics.
 
-Graphic with differently shaped symbols in black in white.:
+Graphic with differently shaped symbols in black in white:
 ![graphic in color with differently shaped symbols]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.27.20-768x588.png)
 ![Graphic with differently shaped symbols in black in white]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.33.58-Kopie-768x629.png)
 

--- a/docs/topics/design/color/use-of-color.md
+++ b/docs/topics/design/color/use-of-color.md
@@ -16,7 +16,7 @@ Using color to differentiate between elements on a page is fine. However, you sh
 
 For example,
 
-- Error, success, or note messages, more info in [Write out an error message in text]({site.baseurl}}/docs/topics/forms/feedback/error-message-format/).
+- Error, success, or notification messages, more info in [Write out an error message in text]({site.baseurl}}/docs/topics/forms/feedback/error-message-format/).
 - Links in the content, more info in [Styling links]({site.baseurl}}/docs/topics/design/links/).
 - Active, hover or focus states, more info in [Styling focus and hover states of interactive HTML elements]({site.baseurl}}/docs/topics/design/focus-hover/).
 - Display information updates.
@@ -39,7 +39,7 @@ Color used as the only indicator for information or functionality:
 ![Graphic: only color used (no symbols)]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.34.46-768x646.png)
 ![Graphic: only color used (in black and white)]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.34.46-Kopie-768x646.png)
 
-The easiest way to check whether your website is usable for color-blind people is to test it in grayscale. When the color information is extracted, you can more easily see whether your website is still understandable.
+The easiest way to check whether your website may be usable by color-blind people is to test it in grayscale. When the color information is extracted, you can more easily see whether your website is still understandable.
 
 ## Resources
 

--- a/docs/topics/design/color/use-of-color.md
+++ b/docs/topics/design/color/use-of-color.md
@@ -4,53 +4,46 @@ layout: default
 parent: Color
 description: Learn best practices for how to use color while also considering accessibility.
 nav_order: 3
+contributors:
+  - Joe Dolson
+  - Maja Benke
+  - Rian Rietveld
 ---
 
 # Using color
 
-Using color to differentiate between elements on a page is fine. However, you should avoid using color as the only visual means to differentiate parts of a page. For example,
+Using color to differentiate between elements on a page is fine. However, you should avoid using color as the only visual means to differentiate parts of a page. 
 
-- error, success, or note messages
-- links in the content
-- active, hover or focus states
-- display information updates
+For example,
 
-Use additional styling to indicate types of information including a change of shape or decoration. For example:
+- Error, success, or note messages, more info in [Write out an error message in text]({site.baseurl}}/docs/topics/forms/feedback/error-message-format/).
+- Links in the content, more info in [Styling links]({site.baseurl}}/docs/topics/design/links/).
+- Active, hover or focus states, more info in [Styling focus and hover states of interactive HTML elements]({site.baseurl}}/docs/topics/design/focus-hover/).
+- Display information updates.
 
-- Change symbols in addition to color
-- Underline links that are embedded in text
-
-Grouped links in sidebars, footers, or in navigation menus frequently don’t need to be underlined. If it is obvious in context that the text is a link, underlines are not required. However, in many cases underlining can increase the usability of your website.
+Use additional styling to indicate types of information including a change of shape or decoration. 
 
 ## Examples
 
 ### Correct
 
-Underline your links, which are placed between text.
-
-Underlined links are easier to see.
-![underlined links in body text]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-05-um-15.01.29-768x497.png)
-
 Use symbols and colors in graphics.
 
-Graphic with differently shaped symbols in black in white.
+Graphic with differently shaped symbols in black in white.:
 ![graphic in color with differently shaped symbols]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.27.20-768x588.png)
 ![Graphic with differently shaped symbols in black in white]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.33.58-Kopie-768x629.png)
 
 ### Incorrect
 
-Links not underlined – color blind users may have trouble distinguish links from text.
-
-Can you see the links now?
-![Links are not seen on grey scale when there is no underline]({{site.baseurl}}/assets/images/grey-scale-links.png)
-
-Color used as the only indicator for information or functionality
+Color used as the only indicator for information or functionality:
 ![Graphic: only color used (no symbols)]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.34.46-768x646.png)
 ![Graphic: only color used (in black and white)]({{site.baseurl}}/assets/images/Bildschirmfoto-2017-08-16-um-10.34.46-Kopie-768x646.png)
 
-The easiest way to check whether your website is usable for colorblind people is to test it in grayscale. When the color information is extracted, you can more easily see whether your website is still understandable.
+The easiest way to check whether your website is usable for color-blind people is to test it in grayscale. When the color information is extracted, you can more easily see whether your website is still understandable.
 
 ## Resources
 
-- Adrian Roselli: [On link underlines](http://adrianroselli.com/2016/06/on-link-underlines.html)
-- WebAxe: [Keep the underline](http://www.webaxe.org/keep-the-underline-text-links/)
+## WCAG Success Criteria for the use of color
+
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/quickref/#use-of-color) (level A).
+- [1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/quickref/#non-text-contrast) (level AA).

--- a/docs/topics/design/links/index.md
+++ b/docs/topics/design/links/index.md
@@ -1,0 +1,46 @@
+---
+title: Styling links
+layout: default
+parent: Design & user experience
+description: When to underline links and when not.
+nav_order: 3
+contributors:
+  - Rian Rietveld
+---
+
+# Styling links
+
+When creating styling for links, the following is best practice for usability and accessibility:
+
+- Underlining links in **paragraphs of text** increases the usability of your website. On the web this is a universal convention that underlined text is a link. 
+- **Grouped links** in sidebars, footers, or in navigation menus frequently don’t need to be underlined. If it is obvious in context that text is a link, underlining is not required.
+- Use underlining of text only for links. Underlining makes people think something is clickable, if they click it and nothing happens, they'll probably be confused and frustrated. 
+
+For styling hover and focus states of links, read [Styling focus and hover states of interactive HTML elements]({{site.baseurl}}/docs/topics/design/focus-hover/).
+
+When you custom style the underlining with CSS, make sure the underlining has a color contrast ratio of at least 3:1 against it's background color.
+
+{: .callout .dont }
+**Don't**: remove the underlining from links and use only a different color. Color-blind visitors (about 8%) may miss the link.   
+I love cats, so I watch <a href="#" style="text-decoration: none; color: darkgreen">cat videos</a> on YouTube.
+
+{: .callout .do }
+**Do**: underline links in the content, everyone gets that it's a link.     
+I love cats, so I watch <a href="#" style="color: darkgreen">cat videos</a> on YouTube.
+
+## Resources
+
+### Related WCAG Success Criteria for styling links
+
+- [1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/quickref/#use-of-color) (level A).
+- [1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/quickref/#non-text-contrast) (level AA).
+
+### Other resources
+
+- [Underline Your Links!](https://theadminbar.com/accessibility-weekly/underline-your-links/), by Amber Hinds on the Admin Bar.
+- [On Link Underlines](https://adrianroselli.com/2016/06/on-link-underlines.html), by Adrian Roselli.
+- [Designing Better Links UX](https://smart-interface-design-patterns.com/articles/links-ux/) on Smart Interface Design Patterns.
+- [Links and Hypertext - Underlining](https://webaim.org/techniques/hypertext/link_text#underlining), on WebAIM.
+- [Guidelines for Visualizing Links](https://www.nngroup.com/articles/guidelines-for-visualizing-links/), by the NNGroup.
+- [Link styling: Underline your links. Test with night mode. Test in greyscale](https://nicsteenhout.substack.com/p/link-styling-underline-your-links), by Nic Steenhout.
+

--- a/docs/topics/design/links/index.md
+++ b/docs/topics/design/links/index.md
@@ -5,25 +5,28 @@ parent: Design & user experience
 description: When to underline links and when not.
 nav_order: 3
 contributors:
+  - Joe Dolson
   - Rian Rietveld
 ---
 
 # Styling links
 
+Best practices for styling links are intended to ensure that links are easily distinguishable from other text on the page. This can be through the design of the link itself, or through the design and structure of the section containing the link, when the links are in a block of navigational content.
+
 When creating styling for links, the following is best practice for usability and accessibility:
 
-- Underlining links in **paragraphs of text** increases the usability of your website. On the web this is a universal convention that underlined text is a link. 
+- Underlining links in **blocks of text** increases the usability of your website. On the web this is a universal convention that underlined text is a link. 
 - **Grouped links** in sidebars, footers, or in navigation menus frequently don’t need to be underlined. If it is obvious in context that text is a link, underlining is not required.
-- Use underlining of text only for links. Underlining makes people think something is clickable, if they click it and nothing happens, they'll probably be confused and frustrated. 
+- Use underlining of text **only** for links. Underlining makes people think your text is clickable; if they click it and nothing happens, they may be confused or frustrated.
 
 Joe Dolson wrote [Why WordPress Themes Require Underlines on Links](https://www.joedolson.com/2025/10/why-wordpress-themes-require-underlines-on-links/) with the reasons why underlining is the best way to indicate links in the content.
 
 For styling hover and focus states of links, read [Styling focus and hover states of interactive HTML elements]({{site.baseurl}}/docs/topics/design/focus-hover/).
 
-When you custom style the underlining with CSS, make sure the underlining has a color contrast ratio of at least 3:1 against its background color.
+When you create your underlining styles with CSS, make sure the underline has a color contrast ratio of at least 3:1 against its background color.
 
 {: .callout .dont }
-**Don't**: remove the underlining from links and use only a different color. Color-blind visitors (about 8%) may miss the link.   
+**Don't**: remove the underlining from links to only use color. Color-blind visitors (about 8% of the population) may miss the link.    
 I love cats, so I watch <a href="#" style="text-decoration: none; color: darkgreen">cat videos</a> on YouTube.
 
 {: .callout .do }
@@ -45,5 +48,5 @@ I love cats, so I watch <a href="#" style="color: darkgreen">cat videos</a> on Y
 - [Designing Better Links UX](https://smart-interface-design-patterns.com/articles/links-ux/) on Smart Interface Design Patterns.
 - [Links and Hypertext - Underlining](https://webaim.org/techniques/hypertext/link_text#underlining), on WebAIM.
 - [Guidelines for Visualizing Links](https://www.nngroup.com/articles/guidelines-for-visualizing-links/), by the NNGroup.
-- [Link styling: Underline your links. Test with night mode. Test in greyscale](https://nicsteenhout.substack.com/p/link-styling-underline-your-links), by Nic Steenhout.
+- [Link styling: Underline your links. Test with night mode. Test in greyscale](https://nicolas-steenhout.com/underline-your-links/), by Nic Steenhout.
 

--- a/docs/topics/design/links/index.md
+++ b/docs/topics/design/links/index.md
@@ -20,7 +20,7 @@ Joe Dolson wrote [Why WordPress Themes Require Underlines on Links](https://www.
 
 For styling hover and focus states of links, read [Styling focus and hover states of interactive HTML elements]({{site.baseurl}}/docs/topics/design/focus-hover/).
 
-When you custom style the underlining with CSS, make sure the underlining has a color contrast ratio of at least 3:1 against it's background color.
+When you custom style the underlining with CSS, make sure the underlining has a color contrast ratio of at least 3:1 against its background color.
 
 {: .callout .dont }
 **Don't**: remove the underlining from links and use only a different color. Color-blind visitors (about 8%) may miss the link.   

--- a/docs/topics/design/links/index.md
+++ b/docs/topics/design/links/index.md
@@ -16,6 +16,8 @@ When creating styling for links, the following is best practice for usability an
 - **Grouped links** in sidebars, footers, or in navigation menus frequently don’t need to be underlined. If it is obvious in context that text is a link, underlining is not required.
 - Use underlining of text only for links. Underlining makes people think something is clickable, if they click it and nothing happens, they'll probably be confused and frustrated. 
 
+Joe Dolson wrote [Why WordPress Themes Require Underlines on Links](https://www.joedolson.com/2025/10/why-wordpress-themes-require-underlines-on-links/) with the reasons why underlining is the best way to indicate links in the content.
+
 For styling hover and focus states of links, read [Styling focus and hover states of interactive HTML elements]({{site.baseurl}}/docs/topics/design/focus-hover/).
 
 When you custom style the underlining with CSS, make sure the underlining has a color contrast ratio of at least 3:1 against it's background color.
@@ -38,6 +40,7 @@ I love cats, so I watch <a href="#" style="color: darkgreen">cat videos</a> on Y
 ### Other resources
 
 - [Underline Your Links!](https://theadminbar.com/accessibility-weekly/underline-your-links/), by Amber Hinds on the Admin Bar.
+- [Why WordPress Themes Require Underlines on Links](https://www.joedolson.com/2025/10/why-wordpress-themes-require-underlines-on-links/), by Joe Dolson.
 - [On Link Underlines](https://adrianroselli.com/2016/06/on-link-underlines.html), by Adrian Roselli.
 - [Designing Better Links UX](https://smart-interface-design-patterns.com/articles/links-ux/) on Smart Interface Design Patterns.
 - [Links and Hypertext - Underlining](https://webaim.org/techniques/hypertext/link_text#underlining), on WebAIM.

--- a/docs/topics/forms/feedback/accessible-error-messages.md
+++ b/docs/topics/forms/feedback/accessible-error-messages.md
@@ -104,7 +104,7 @@ HTML5 form validation is not accessible at this moment (in 2025). The W3C summar
 
 ### How do I indicate that an answer is incomplete or filled out incorrectly?
 
-Use more than color alone to indicate errors. A user with visual impairments or color blindness may not notice a red outline. Color is helpful but always include an error message in text too.
+Use more than color alone to indicate errors. A user with visual impairments or color-blindness may not notice a red outline. Color is helpful but always include an error message in text too.
 
 * Clearly state whether a field is required.
 * Show errors with more than just color or an icon.


### PR DESCRIPTION

The related issue number: #110, #112,  #117, #118, #130

Preview in content:

- [Link texts](https://wpaccessibility.org/pr-preview/pr-314/docs/topics/content/links/link-text/).
- [Images as links](https://wpaccessibility.org/pr-preview/pr-314/docs/topics/content/links/link-image/).
- [Link destinations](https://wpaccessibility.org/pr-preview/pr-314/docs/topics/content/links/link-destinations/).

Preview in design:
- [Styling links](https://wpaccessibility.org/pr-preview/pr-314/docs/topics/design/links/), new page.
- [Using color](https://wpaccessibility.org/pr-preview/pr-314/docs/topics/design/color/use-of-color/), updated only for the link info, needs more content, but not in this PR.

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [x] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

