### PR TITLE
docs: make dummy links self-referencing to preserve viewport position

### DIFF
--- a/docs/topics/content/links/link-destinations.md
+++ b/docs/topics/content/links/link-destinations.md
@@ -29,7 +29,7 @@ If you absolutely need to open a link in a new window, you need to tell your vis
 
 {: .callout .example }
 For example:     
-I love cats, so I watch [cat videos (opens in a new tab)](#) on YouTube.
+I love cats, so I watch <a href="#self-1" id="self-1">cat videos (opens in a new tab)</a> on YouTube.
 
 
 ## Link to a document
@@ -38,8 +38,8 @@ If the link opens a document, add the format of the document in the link text.
 
 {: .callout .example }
 For example:    
-You can [download the manual as PDF](#).    
-Please [download our terms (PDF, 3Mb)](#).
+You can <a href="#self-2" id="self-2">download the manual as PDF</a>.    
+Please <a href="#self-3" id="self-3">download our terms (PDF, 3Mb)</a>.
 
 ## Resources
 

--- a/docs/topics/content/links/link-text.md
+++ b/docs/topics/content/links/link-text.md
@@ -57,11 +57,11 @@ ASCII art is invariably meaningless to screen reader users. Emoticons are occasi
 
 {: .callout .dont }
 **Don't**: overload your link text with emoji.     
-[I 👏 approve 👏 this 👏 message 👏 ](#).
+<a href="#self-1" id="self-1">I 👏 approve 👏 this 👏 message 👏 </a>.
 
 {: .callout .do }
 **Do**: keep your link text clean, to the point and simple.  
-[I approve this message](#) 👏 .
+<a href="#self-2" id="self-2">I approve this message</a> 👏 .
 
 
 ## Avoid writing links in all caps
@@ -70,11 +70,11 @@ Sequences of all capital letters are harder to read for people with dyslexia, sc
 
 {: .callout .dont }
 **Don't**: use all caps as link text.      
-<a href="#">ACT NOW</a>.
+<a href="#self-3" id="self-3">ACT NOW</a>.
 
 {: .callout .do }
 **Do**: use sentence case or title case as link text.    
-<a href="#">Act now</a> or <a href="#">Act Now</a>.   
+<a href="#self-4" id="self-4">Act now</a> or <a href="#self-5" id="self-5">Act Now</a>.   
 
 ## Avoid using complete URLs as link text
 
@@ -97,12 +97,12 @@ In addition, screen readers announce the title attribute inconsistently. You mus
 {: .callout .dont }
 **Don't**: use a title attribute on links.   
 `<a href="some-url" title="download the PDF">manual</a>`    
-<a href="#" title="download the PDF">manual</a>
+<a href="#self-6" id="self-6" title="download the PDF">manual</a>
 
 {: .callout .do }
 **Do**: add all info in the link text, so everyone has the same information and it is always visible.  
 `<a href="some-url">download the manual as PDF</a>`    
-<a href="#">download the manual as PDF</a>
+<a href="#self-7" id="self-7">download the manual as PDF</a>
 
 ## Resources
 

--- a/docs/topics/design/links/index.md
+++ b/docs/topics/design/links/index.md
@@ -27,11 +27,11 @@ When you create your underlining styles with CSS, make sure the underline has a 
 
 {: .callout .dont }
 **Don't**: remove the underlining from links to only use color. Color-blind visitors (about 8% of the population) may miss the link.    
-I love cats, so I watch <a href="#" style="text-decoration: none; color: darkgreen">cat videos</a> on YouTube.
+I love cats, so I watch <a href="#self-1" id="self-1" style="text-decoration: none; color: darkgreen">cat videos</a> on YouTube.
 
 {: .callout .do }
 **Do**: underline links in the content, everyone gets that it's a link.     
-I love cats, so I watch <a href="#" style="color: darkgreen">cat videos</a> on YouTube.
+I love cats, so I watch <a href="#self-2" id="self-2" style="color: darkgreen">cat videos</a> on YouTube.
 
 ## Resources
 

--- a/docs/topics/forms/feedback/accessible-error-messages.md
+++ b/docs/topics/forms/feedback/accessible-error-messages.md
@@ -130,7 +130,7 @@ Give users clear confirmation that their form has been submitted and what will h
 
 {: .callout  .example }
 A confirmation text could be:  
-Thank you for your registration for our workshop "Knitting socks". A confirmation email has been sent to user@example.com with the time and location of the workshop. If you haven't received an email? [Please contact us](#).
+Thank you for your registration for our workshop "Knitting socks". A confirmation email has been sent to user@example.com with the time and location of the workshop. If you haven't received an email? <a href="#self-1" id="self-1">Please contact us</a>.
 
 ### How can I offer help if a user gets stuck?
 
@@ -142,7 +142,7 @@ Always offer multiple ways to get in touch on your contact page — not everyone
 
 {: .callout  .example }
 A help text could be:  
-Do you need help filling out this form or do you have questions? [Please contact us](#).
+Do you need help filling out this form or do you have questions? <a href="#self-2" id="self-2">Please contact us</a>.
 
 ## Conclusion
 

--- a/docs/topics/forms/input-label/text-only.md
+++ b/docs/topics/forms/input-label/text-only.md
@@ -43,7 +43,7 @@ The populair [WordPress form plugin Contact Form 7](https://wordpress.org/plugin
 
 {: .callout .do }
 Place the link to the terms of delivery outside and above the label.  
-[The terms of delivery](#).  
+<a href="#self-1" id="self-1">The terms of delivery</a>.  
 <input id="alv3" type="checkbox"/>
 <label for="alv3">I agree with the terms of delivery</label>
 
@@ -60,7 +60,7 @@ Note that the reading order is also meaningful: first the link to the terms and 
 {: .callout .dont }
 Place the link to the terms of delivery inside the label.  
 <input id="alv4" type="checkbox"/>
-<label for="alv4">I agree with [the terms of delivery](#)</label>
+<label for="alv4">I agree with <a href="#self-2" id="self-2">the terms of delivery</a></label>
 
 
 ```html


### PR DESCRIPTION
## Summary

Closes #320. Replaces 16 dummy links (`<a href="#">` and `[text](#)`) across six pages with self-referencing anchors (`<a href="#self-N" id="self-N">text</a>`) so clicking an example link in the content no longer scrolls the page to the top.

## Why this matters

Every "Do / Don't" callout on the site is currently a demo link with `href="#"`. When a reader clicks one — and on this site that's expected behavior, the pages actively invite interaction with the examples — the browser jumps to the top of the page. Self-referencing anchors land the click on the link itself, so the viewport position and focus stay where they are. That's the point the issue (rianrietveld) makes.

## Changes

Converted links in these pages:

- `docs/topics/design/links/index.md` (2)
- `docs/topics/forms/input-label/text-only.md` (2)
- `docs/topics/forms/feedback/accessible-error-messages.md` (2)
- `docs/topics/content/links/link-text.md` (7)
- `docs/topics/content/links/link-destinations.md` (3)

`docs/topics/code/semantics/index.md` has a dummy `href="#"` but it lives inside a fenced code block that's showing wrong HTML to avoid — that one stayed as-is (rendered as source, not as a clickable link, so it doesn't jump anyway).

Format chosen: raw HTML `<a href="#self-N" id="self-N">text</a>` rather than kramdown IAL, so the output is identical whether the markdown processor is kramdown or something else. Matches the issue's suggested syntax.

IDs are page-local (`self-1`, `self-2`, …) and reset per file, so each generated page stays valid HTML without id collisions.

## Testing

Local `git diff --stat`: 5 files, +15/-15. No Jekyll build change expected beyond the output `<a>` tags.

## AI disclosure

This contribution was developed with AI assistance (Claude Code).
