### PR TITLE
Fix typo in setup documentation

### DIFF
--- a/docs/testing/testing-themes/setup.md
+++ b/docs/testing/testing-themes/setup.md
@@ -11,7 +11,7 @@ nav_order: 2
 ## Creating the test site
 To accessibility-ready test a theme, you will first need to set up a testing environment. 
 
-It is important to note that browser extensions for accessibility testing do not current work in WordPress Playground. As a result, you can't use Playground for accessibility-ready reviews. 
+It is important to note that browser extensions for accessibility testing do not currently work in WordPress Playground. As a result, you can't use Playground for accessibility-ready reviews. 
 
 Outside of Playground, reviews can be done in any WordPress environment you prefer. For convenience, we have a template site available for quick spin-up via [InstaWP](https://instawp.com). 
 


### PR DESCRIPTION
## Summary

Fix a typo in the Setup documentation page.

Changes:

* Replace "current" with "currently" in the note about browser extensions for accessibility testing and WordPress Playground.

Fixes #340 

Before submitting this PR, please make sure:
- [ ] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

