### PR TITLE
Set min-height on contained links to 48 and center

### DIFF
--- a/_sass/layout/_navigation.scss
+++ b/_sass/layout/_navigation.scss
@@ -109,6 +109,9 @@
 
         .nav-list-link {
           color: $nav-child-link-color;
+		  min-height: 48px;
+		  display: flex;
+		  align-items: center;
 
           &.active {
             color: var(--color-wa11ypuu-yellow);


### PR DESCRIPTION
See #357

Thank you for your contribution to the WP Accessibility Knowledge Base.

The related issue number: #

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [ ] One of the project leads assigned this task to you.
- [ ] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [ ] Your code builds clean without any errors or warnings while running `npm run test`.
- [ ] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

