### PR TITLE
Fix some broken links

### DIFF
--- a/docs/accessibility-ready/testing-themes/reporting-sheet.md
+++ b/docs/accessibility-ready/testing-themes/reporting-sheet.md
@@ -13,7 +13,7 @@ redirect_from:
 
 # Reporting sheet overview
 
-As described in _[Getting set up to test]({{site.baseurl}}/docs/accessibility-ready/theme-guidelines/setup/)_, accessibility ready reports are generated using a Google Sheets template. This ensures that all reports are consistent between testers and helps guide the testing process so nothing is missed. The reporting sheet has three tabs which are described in detail below.
+As described in _[Getting set up to test]({{site.baseurl}}/docs/accessibility-ready/testing-themes/setup/)_, accessibility ready reports are generated using a Google Sheets template. This ensures that all reports are consistent between testers and helps guide the testing process so nothing is missed. The reporting sheet has three tabs which are described in detail below.
 
 [View the Accessibility Ready Test Report Template](https://docs.google.com/spreadsheets/d/1sIHAPwwQIoJVj1ODg2FX2L_wf_CLNMLekQ2D-MvWGq4/edit?usp=sharing)
 
@@ -148,7 +148,7 @@ This tab exists to:
 
 ### Structure of the generated markdown
 
-The output on this tab is intentionally formatted to work with Trac’s Markdown-like syntax, and includes the correct heading levels when pasted into a Trac comment, which starts with an H3 heading. 
+The output on this tab is intentionally formatted to work with Trac’s Markdown-like syntax, and includes the correct heading levels when pasted into a Trac comment, which starts with an H3 heading.
 
 In order for the report to fully function, the following fields must be completed:
 

--- a/docs/accessibility-ready/testing-themes/setup.md
+++ b/docs/accessibility-ready/testing-themes/setup.md
@@ -14,16 +14,16 @@ redirect_from:
 # Getting set up to test
 
 ## Creating the test site
-To accessibility-ready test a theme, you will first need to set up a testing environment. 
+To accessibility-ready test a theme, you will first need to set up a testing environment.
 
-It is important to note that browser extensions for accessibility testing do not currently work in WordPress Playground. As a result, you can't use Playground for accessibility-ready reviews. 
+It is important to note that browser extensions for accessibility testing do not currently work in WordPress Playground. As a result, you can't use Playground for accessibility-ready reviews.
 
-Outside of Playground, reviews can be done in any WordPress environment you prefer. For convenience, we have a template site available for quick spin-up via [InstaWP](https://instawp.com). 
+Outside of Playground, reviews can be done in any WordPress environment you prefer. For convenience, we have a template site available for quick spin-up via [InstaWP](https://instawp.com).
 
 ### Why use our InstaWP testing site
 You may be wondering why we recommend using our InstaWP template for testing rather than loading the theme up on any other WordPress site. Here's why:
 
-Our InstaWP template has demo content including pages, posts, media, and navigation menus already configured so you can get started testing faster. We have also gone through the standard [WordPress theme unit test data](https://make.wordpress.org/themes/handbook/review/theme-unit-test/) and remediated accessibility issues to avoid false positives. 
+Our InstaWP template has demo content including pages, posts, media, and navigation menus already configured so you can get started testing faster. We have also gone through the standard [WordPress theme unit test data](https://make.wordpress.org/themes/handbook/review/theme-unit-test/) and remediated accessibility issues to avoid false positives.
 
 Additionally, specific pages and URLs from this site are referenced in the report template. For this reason, we recommend starting with an InstaWP testing site. If you prefer to test elsewhere, you can export the InstaWP content and import it into a different site using the [WordPress Importer plugin.](https://wordpress.org/plugins/wordpress-importer/)
 
@@ -40,7 +40,7 @@ Here's how to create a testing site from our template:
 4. Check the box acknowledging the privacy notice.
 5. Click the "proceed" button.
 
-The website should be created in a matter of minutes and you will be automatically logged into the site. 
+The website should be created in a matter of minutes and you will be automatically logged into the site.
 
 An email will be sent to you with the web address and admin credentials for logging into the website should you need to revisit the site later.
 
@@ -52,7 +52,7 @@ After creating the site, you need to install and setup the theme for testing. He
 
 #### Installing and activating the theme
 
-1. Determine if you're testing a new theme or existing theme. ([See Identifying themes that need to be tested]({{site.baseurl}}/docs/accessibility-ready/theme-guidelines/identifying-themes/)) 
+1. Determine if you're testing a new theme or existing theme. ([See Identifying themes that need to be tested]({{site.baseurl}}/docs/accessibility-ready/testing-themes/identifying-themes/))
 2. Install the theme in the testing site following these instructions:
     1. If the theme is a new theme or an existing theme with an unreleased new version:
         1. Go to the Trac ticket for the theme.
@@ -70,7 +70,7 @@ After creating the site, you need to install and setup the theme for testing. He
 
 #### Configuring the theme
 
-Once the theme is active, you need to configure the theme content for testing. The following steps assume you're starting with our InstaWP template content, in which case the setup work should be minimal. 
+Once the theme is active, you need to configure the theme content for testing. The following steps assume you're starting with our InstaWP template content, in which case the setup work should be minimal.
 
 After activating the theme, do the following:
 
@@ -89,7 +89,7 @@ After activating the theme, do the following:
     6. Save the page.
 5. Configure any other available settings.
     1. If the theme supports the Customizer, open the Customizer and check for theme settings that need to be configured.
-    2. Check for a theme settings page and enable settings there as needed. 
+    2. Check for a theme settings page and enable settings there as needed.
 
 Examples of other settings you may need to enable in the theme Customizer or settings pages include:
 * Show search in header.

--- a/docs/accessibility-ready/testing-themes/theme-testing-workflow.md
+++ b/docs/accessibility-ready/testing-themes/theme-testing-workflow.md
@@ -13,7 +13,7 @@ redirect_from:
 
 # Testing workflow tips
 
-Once you have [set up your test site and reporting document]({{site.baseurl}}/docs/accessibility-ready/theme-guidelines/setup/), you can begin the theme testing process. The guidance below focuses on how to test efficiently and report issues quickly. 
+Once you have [set up your test site and reporting document]({{site.baseurl}}/docs/accessibility-ready/testing-themes/setup/), you can begin the theme testing process. The guidance below focuses on how to test efficiently and report issues quickly.
 
 ## Consider your browser window layout
 
@@ -32,7 +32,7 @@ There is no single “correct” way to move through Accessibility Ready testing
 
 In this approach, you load one page (for example, the front page) and test all applicable accessibility requirements before moving on to the next page.
 
-This approach is recommended if you prefer linear, page-based workflows. It mirrors the typical accessibility auditing process and is helpful if you expect to identify many failures (perhaps because you saw some while configuring the theme), and want the fastest understanding of status to report back to the theme developer. 
+This approach is recommended if you prefer linear, page-based workflows. It mirrors the typical accessibility auditing process and is helpful if you expect to identify many failures (perhaps because you saw some while configuring the theme), and want the fastest understanding of status to report back to the theme developer.
 
 On the other hand, this approach may make testing and reporting slower because it requires more switching between tools and techniques than if you test a single check across all pages.
 
@@ -50,7 +50,7 @@ Many experienced testers use a **hybrid approach**, starting with single-check t
 
 If you are:
 * **New to Accessibility Ready testing**: testing one check at a time across all pages may feel less overwhelming and help you gain confidence in testing.
-* **Seeing early, obvious failures**: testing multiple checks on a single page (like the home page) gives you a better understanding of what needs to be fixed when you report back to the theme developer.  
+* **Seeing early, obvious failures**: testing multiple checks on a single page (like the home page) gives you a better understanding of what needs to be fixed when you report back to the theme developer.
 
 Whichever approach you choose, consistency in your process matters more than the order in which you test. One you get started you'll build a rhythm and each accessibility ready review will get easier as you go.
 
@@ -69,7 +69,7 @@ If you quickly identify multiple failures such as:
 * Empty buttons or links
 * Problems easily identified with a browser extension
 
-**You may stop testing early.** 
+**You may stop testing early.**
 
 We appreciate your time as a volunteer tester. We don't expect you to spend hours testing a theme and reporting in detail failures on every row. It's ok to document representative issues, stop testing, and share the already identified failures with the theme developer, requesting fixes before you continue testing.
 

--- a/docs/accessibility-ready/theme-guidelines/index.md
+++ b/docs/accessibility-ready/theme-guidelines/index.md
@@ -21,4 +21,4 @@ This section outlines the `accessibility-ready` requirements with testing instru
 For additional information about the accessibility ready testing process, see:
 
 * [Theme developer handbook: Accessibility](https://make.wordpress.org/themes/handbook/review/accessibility/)
-* [Accessibility-ready testing process]({{site.baseurl}}/docs/accessibility-ready/theme-guidelines/)
+* [Accessibility-ready testing process]({{site.baseurl}}/docs/accessibility-ready/testing-themes/)


### PR DESCRIPTION
These links all point to theme-guidelines instead of testing-themes.

Thank you for your contribution to the WP Accessibility Knowledge Base.

The related issue number: #

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [ ] One of the project leads assigned this task to you.
- [ ] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [ ] Your code builds clean without any errors or warnings while running `npm run test`.
- [ ] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

