### PR TITLE
Change in aria-label in the footer after feedback screen reader user

### DIFF
--- a/_includes/components/footer.html
+++ b/_includes/components/footer.html
@@ -2,7 +2,7 @@
   <footer>
 
     <nav aria-label="Footer">
-      <h2 class="screen-reader-text">Quick links and main content</h2>
+      <h2 class="screen-reader-text">Quick links and main topics</h2>
 
       <div class="container">
 
@@ -43,4 +43,3 @@
     </nav>
 
   </footer>
-


### PR DESCRIPTION
Last week @bramd, a blind developer and accessibility specialist looked at the structure of wpaccessibiulity.org and found only one issue. 🎉 

The current text is
`<h2 class="screen-reader-text">Quick links and main content</h2>`
He found this confusing and proposed
`<h2 class="screen-reader-text">Quick links and main topics</h2>`

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [x] Your code builds clean without any errors or warnings while running `npm run test`.
- [x] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [x] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

