### PR TITLE
tweak section on EN 301 549

### DIFF
--- a/docs/topics/legislation/index.md
+++ b/docs/topics/legislation/index.md
@@ -69,7 +69,7 @@ Learn more [about Web Accessibility Directive](https://digital-strategy.ec.europ
 
 ## EN 301 549
 
-In Europe, the WAD as well as the EAA point to accessibility requirements for ICT products and services, as published in a document called EN 301 549. The EN stands for European Norm. It draws heavily from the WCAG 2.1, adapted for specific needs per country. In this document you will find accessibility guidelines for everything from websites to closed software. The [European Commmission has mentioned that EU member states are free to use WCAG 2.2](https://digital-strategy.ec.europa.eu/en/policies/web-accessibility-directive-standards-and-harmonisation) if they wish.
+In Europe, a standard that is relevant for WAD as well as the EAA is EN 301 549. “EN” stands for European Norm, and it contains accessibility requirements for ICT products and services. For almost all requirements that apply to websites and apps, EN 301 549 references WCAG 2. EN 301 549 also contains requirements beyond websites and apps, such as closed software, real-time communication devices and stationary hardware . 
 
 {: .callout .alert}
 **Fair warning**: meeting all the success criteria for WCAG 2.1 or 2.2 will not ensure presumption of conformity with WAD or EAA, since EN 301 549 has extra requirements. So it's an important document to keep an eye on.


### PR DESCRIPTION
A few suggested updates: 

- “the WAD as well as the EAA point to accessibility requirements for ICT products and services, as published in a document called EN 301 549” this statement isn't true; WAD mentions the EN, EAA does not. The most important relationship between both WAD and EAA and the EN is in the Official Journal that announces EN provides presumption of conformity. The new wording avoids this nuance, as it is a bit technical, what matters is that the EN is an important doc.
- remove the distinction between 2.1 and 2.2. The 3.2.1 version of the EN references WCAG 2.1, the 4.1.0 version references WCAG 2.2. The 4.1.0 version is expected to be published within the next few months, this change will continue to work when that happens.
- add more examples of things EN covers and explicitly say these are things that are beyond websites and apps.

--- 

Thank you for your contribution to the WP Accessibility Knowledge Base.

The related issue number: n/a

**Please note:**
Content committed without [contacting the project leads](https://wpaccessibility.org/docs/contact/) first, will not be reviewed.

Before submitting this PR, please make sure:
- [x] One of the project leads assigned this task to you.
- [x] You did not generate content using AI (artificial intelligence), except for translations or spelling checks.

If you submit code or documentation using a local build:
- [ ] Your code builds clean without any errors or warnings while running `npm run test`.
- [ ] You read the documentation in [How to contribute to this documentation](https://wpaccessibility.org/docs/about/contribute/).
- [ ] You checked the modified pages with an accessibility tool like [Axe Devtools](https://www.deque.com/axe/devtools/edge-browser-extension/) or [WAVE](https://wave.webaim.org/).

