### PR TITLE
Use labeled spelling for form fields

### DIFF
--- a/docs/accessibility-ready/theme-guidelines/labeled-form-fields.md
+++ b/docs/accessibility-ready/theme-guidelines/labeled-form-fields.md
@@ -1,5 +1,5 @@
 ---
-title: Labelled form fields
+title: Labeled form fields
 layout: default
 parent: Theme accessibility-ready guidelines
 description: Accessibility-ready theme requirements for how to label form fields
@@ -9,9 +9,10 @@ contributors:
   - Joe Dolson
 redirect_from:
   - /docs/topics/theme-guidelines/labelled-form-fields/
+  - /docs/accessibility-ready/theme-guidelines/labelled-form-fields/
 ---
 
-# Labelled form fields
+# Labeled form fields
 
 ## Basic principle
 


### PR DESCRIPTION
# Use labeled spelling for form fields

## Summary

Corrects the spelling of the accessibility-ready form-fields page from “labelled” to “labeled.” The page keeps redirects for both existing labelled-form-fields URLs so established links continue to resolve.

Fixes #391

## Changes

- Renamed the form-fields documentation page to `labeled-form-fields.md`.
- Updated the page title and heading to use “Labeled.”
- Added a redirect for the previous accessibility-ready page URL while retaining the existing legacy redirect.

## Testing

- Passed: `sandbox-run --no-net "test -f docs/accessibility-ready/theme-guidelines/labeled-form-fields.md && test ! -f docs/accessibility-ready/theme-guidelines/labelled-form-fields.md && grep -Fxq 'title: Labeled form fields' docs/accessibility-ready/theme-guidelines/labeled-form-fields.md && grep -Fxq '# Labeled form fields' docs/accessibility-ready/theme-guidelines/labeled-form-fields.md && grep -Fxq '  - /docs/topics/theme-guidelines/labelled-form-fields/' docs/accessibility-ready/theme-guidelines/labeled-form-fields.md && grep -Fxq '  - /docs/accessibility-ready/theme-guidelines/labelled-form-fields/' docs/accessibility-ready/theme-guidelines/labeled-form-fields.md"`
- `sandbox-run "npm ci && npm test"` completed dependency installation but failed because the pre-existing `_sass/layout/_navigation.scss` does not meet Prettier formatting.
- `sandbox-run "bundle install && bundle exec jekyll build"` could not run because `bundle` is unavailable in the sandbox image.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
